### PR TITLE
Linearizability tests for Queue and Stack module

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,6 +6,7 @@
        (alias neg_tests/default)
        (alias domainslib/default)
        (alias lockfree/default)
+       (alias queue/default)
        ;; (alias kcas/default)  -- kcas tests disabled
        ))
 

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -1,0 +1,28 @@
+;; Linearizability tests of the stdlib Queue library
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (deps lin_tests.exe))
+
+(env
+ (_
+  (binaries
+   (../check_error_count.exe as check_error_count))))
+
+
+(executable
+ (name lin_tests)
+ (modules lin_tests)
+ (flags (:standard -w -27))
+ (libraries util qcheck lin)
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (with-accepted-exit-codes 0
+    (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
+   (cat lin-output.txt)
+    (run %{bin:check_error_count} "lin_tests" 0 lin-output.txt))))

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -22,7 +22,7 @@
  (alias runtest)
  (action
   (progn
-   (with-accepted-exit-codes 0
+   (with-accepted-exit-codes 1
     (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
    (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 0 lin-output.txt))))
+    (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -1,0 +1,81 @@
+open QCheck
+
+module QConf =
+  struct
+    type t = int Queue.t
+
+    let m = Mutex.create ()
+    
+    type cmd =
+      | Add of int'
+      | Take
+      | Take_opt
+      | Peek
+      | Peek_opt
+      | Clear
+      | Is_empty
+      | Length [@@deriving qcheck, show { with_path = false }]
+    and int' = int [@gen Gen.nat]
+
+    type res =
+      | RAdd
+      | RTake of int option
+      | RTake_opt of int option
+      | RPeek of int option
+      | RPeek_opt of int option
+      | RClear
+      | RIs_empty of bool
+      | RLength of int [@@deriving show { with_path = false }]
+
+    let init () = Queue.create ()
+
+    let run c q = match c with
+      | Add i    -> Mutex.lock m;
+                    Queue.add i q;
+                    Mutex.unlock m; RAdd
+      | Length   -> Mutex.lock m;
+                    let l = Queue.length q in
+                    Mutex.unlock m;
+                    RLength l
+      | Clear    -> Mutex.lock m;
+                    Queue.clear q;
+                    Mutex.unlock m;
+                    RClear
+      | Is_empty -> Mutex.lock m;
+                    let b = Queue.is_empty q in
+                    Mutex.unlock m;
+                    RIs_empty b
+      | Peek     -> Mutex.lock m;
+                    let r =
+                     (try Some (Queue.peek q)
+                      with Queue.Empty -> None)
+                    in
+                    Mutex.unlock m;
+                    RPeek r
+      | Peek_opt -> Mutex.lock m;
+                    let r = Queue.peek_opt q in
+                    Mutex.unlock m;
+                    RPeek_opt r
+      | Take     -> Mutex.lock m;
+                    let r =
+                      try Some (Queue.take q)
+                      with Queue.Empty -> None
+                    in
+                    Mutex.unlock m;
+                    RTake r
+      | Take_opt -> Mutex.lock m;
+                    let r = Queue.take_opt q in
+                    Mutex.unlock m;
+                    RTake_opt r
+
+    let cleanup _ = ()
+  end
+
+module QT = Lin.Make(QConf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+    QT.lin_test `Domain ~count:1000 ~name:"Queue test with domains" ;
+    QT.lin_test `Thread ~count:1000 ~name:"Queue test with threads"
+  ]

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -22,7 +22,7 @@
  (alias runtest)
  (action
   (progn
-   (with-accepted-exit-codes 0
+   (with-accepted-exit-codes 1
     (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
    (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 0 lin-output.txt))))
+    (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -13,8 +13,10 @@ module Spec =
       | Top_opt
       | Clear
       | Is_empty
+      | Fold of fct * int' 
       | Length [@@deriving qcheck, show { with_path = false }]
     and int' = int [@gen Gen.nat]
+    and fct = (int -> int -> int) fun_ [@printer fun fmt f -> fprintf fmt "%s" (Fn.print f)] [@gen (fun2 Observable.int Observable.int int).gen] 
 
     type res =
       | RPush
@@ -24,6 +26,7 @@ module Spec =
       | RTop_opt of int option
       | RClear
       | RIs_empty of bool
+      | RFold of int
       | RLength of int [@@deriving show { with_path = false }]
 
     let init () = Stack.create ()
@@ -33,63 +36,68 @@ module Spec =
 module SConf =
   struct
     include Spec
-    let run c q = match c with
-      | Push i   -> Stack.push i q; RPush
-      | Length   -> RLength (Stack.length q) 
-      | Clear    -> Stack.clear q; RClear
-      | Is_empty -> RIs_empty (Stack.is_empty q) 
-      | Top      -> RTop (
-                      try Some (Stack.top q)
-                      with Stack.Empty -> None)
-      | Top_opt  -> RTop_opt (Stack.top_opt q) 
-      | Pop      -> RPop (
-                      try Some (Stack.pop q)
-                      with Stack.Empty -> None)
-      | Pop_opt  -> RPop_opt (Stack.pop_opt q)
+    let run c s = match c with
+      | Push i      -> Stack.push i s; RPush
+      | Pop         -> RPop (
+                           try Some (Stack.pop s)
+                           with Stack.Empty -> None)
+      | Pop_opt     -> RPop_opt (Stack.pop_opt s)
+      | Top         -> RTop (
+                           try Some (Stack.top s)
+                           with Stack.Empty -> None)
+      | Top_opt     -> RTop_opt (Stack.top_opt s) 
+      | Clear       -> Stack.clear s; RClear
+      | Is_empty    -> RIs_empty (Stack.is_empty s) 
+      | Fold (f, a) -> RFold (Stack.fold (Fn.apply f) a s)
+      | Length      -> RLength (Stack.length s) 
     
   end
 
 module SMutexConf =
   struct
     include Spec
-    let run c q = match c with
-      | Push i   -> Mutex.lock m;
-                    Stack.push i q;
-                    Mutex.unlock m; RPush
-      | Length   -> Mutex.lock m;
-                    let l = Stack.length q in
-                    Mutex.unlock m;
-                    RLength l
-      | Clear    -> Mutex.lock m;
-                    Stack.clear q;
-                    Mutex.unlock m;
-                    RClear
-      | Is_empty -> Mutex.lock m;
-                    let b = Stack.is_empty q in
-                    Mutex.unlock m;
-                    RIs_empty b
-      | Top      -> Mutex.lock m;
-                    let r =
-                      (try Some (Stack.top q)
-                       with Stack.Empty -> None)
-                    in
-                    Mutex.unlock m;
-                    RTop r
-      | Top_opt  -> Mutex.lock m;
-                    let r = Stack.top_opt q in
-                    Mutex.unlock m;
-                    RTop_opt r
-      | Pop      -> Mutex.lock m;
-                    let r =
-                      try Some (Stack.pop q)
-                      with Stack.Empty -> None
-                    in
-                    Mutex.unlock m;
-                    RPop r
-      | Pop_opt  -> Mutex.lock m;
-                    let r = Stack.pop_opt q in
-                    Mutex.unlock m;
-                    RPop_opt r
+    let run c s = match c with
+      | Push i      -> Mutex.lock m;
+                       Stack.push i s;
+                       Mutex.unlock m; RPush
+      | Pop         -> Mutex.lock m;
+                       let r =
+                         try Some (Stack.pop s)
+                         with Stack.Empty -> None
+                       in
+                       Mutex.unlock m;
+                       RPop r
+      | Pop_opt     -> Mutex.lock m;
+                       let r = Stack.pop_opt s in
+                       Mutex.unlock m;
+                       RPop_opt r
+      | Top         -> Mutex.lock m;
+                       let r =
+                         try Some (Stack.top s)
+                         with Stack.Empty -> None
+                       in
+                       Mutex.unlock m;
+                       RTop r
+      | Top_opt     -> Mutex.lock m;
+                       let r = Stack.top_opt s in
+                       Mutex.unlock m;
+                       RTop_opt r
+      | Clear       -> Mutex.lock m;
+                       Stack.clear s;
+                       Mutex.unlock m;
+                       RClear
+      | Is_empty    -> Mutex.lock m;
+                       let b = Stack.is_empty s in
+                       Mutex.unlock m;
+                       RIs_empty b
+      | Fold (f, a) -> Mutex.lock m;
+                       let r  = Stack.fold (Fn.apply f) a s in
+                       Mutex.unlock m;
+                       RFold r
+      | Length      -> Mutex.lock m;
+                       let l = Stack.length s in
+                       Mutex.unlock m;
+                       RLength l
   end
 
 module ST = Lin.Make(SConf)
@@ -98,8 +106,8 @@ module SMT = Lin.Make(SMutexConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-    ST.lin_test `Domain ~count:1000 ~name:"Stack test with domains without mutex";
-    ST.lin_test `Thread ~count:1000 ~name:"Stack test with threads without mutex";
     SMT.lin_test `Domain ~count:1000 ~name:"Stack test with domains and mutex";
     SMT.lin_test `Thread ~count:1000 ~name:"Stack test with threads and mutex";
+    ST.lin_test `Domain ~count:1000 ~name:"Stack test with domains without mutex";
+    ST.lin_test `Thread ~count:1000 ~name:"Stack test with threads without mutex";
   ]


### PR DESCRIPTION
- each command is protected by a Mutex
- FIXME: commands that should return an `int` return an `int arbitrary`