### PR TITLE
Put Lin and STM libraries in a standalone package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ experimental code where I'm still playing with various implementation
 choices and the interface design (it should probably use GADTs
 instead). Consider yourself warned.
 
-[lib/STM.ml](lib/STM.ml) contains a revision of qcstm that has been
+The [`stm` package](stm.opam) contains a revision of qcstm that has been
 extended with parallel tests. `agree_test` comes in two parallel variants
-for now:
+for now (see [lib/STM.ml](lib/STM.ml)):
 
  - `agree_test_par` which tests in parallel by `spawn`ing two domains
    from `Domain` directly and
@@ -44,15 +44,6 @@ these a counter example is consistently found and shrunk:
 
  - [src/neg_tests/conclist_test.ml](src/neg_tests/conclist_test.ml) tests a buggy concurrent list.
 
-Building and running the tests
-==============================
-
-The test suite can be run with the following commands:
-```
-opam install . --deps-only --with-test
-opam exec -- dune build
-opam exec -- dune runtest
-```
 
 A Linearization Tester
 ======================
@@ -63,6 +54,9 @@ command requires a bit of effort. This prompted me to carve out a
 module `Lin` in [lib/lin.ml](lib/lin.ml) thus tests that the results
 observed during a parallel run is explainable by some linearized,
 sequential run of the same commands.
+
+This module can be used as a library by installing the [`lin`
+package](lin.opam).
 
 - [src/lin_tests.ml](src/lin_tests.ml) contains experimental
   `Lin`-tests of `Atomic` and `Hashtbl`
@@ -79,6 +73,23 @@ sequential run of the same commands.
 
 - [src/kcas/lin_tests.ml](src/kcas/lin_tests.ml) contains experimental
   `Lin`-tests of `Kcas` and `Kcas.W1` (Note: `Kcas` is subsumed by `Stdlib.Atomic`).
+
+
+Installation instructions, and running the tests
+================================================
+
+The test suite can be run with the following commands:
+```
+opam install . --deps-only --with-test
+opam exec -- dune build
+opam exec -- dune runtest
+```
+
+Package `lin` and `stm` can be installed with:
+```
+opam install ./lin.opam
+opam install ./stm.opam
+```
 
 
 Current (experimental) PBTs of multicore

--- a/dune
+++ b/dune
@@ -1,4 +1,5 @@
 ;; make `dune build` target a recursive default target
 (alias
  (name default)
+ (package multicoretests)
  (deps (alias src/default)))

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.9)
+(name multicoretests)

--- a/lib/dune
+++ b/lib/dune
@@ -5,10 +5,12 @@
 
 (library
  (name STM)
+ (public_name stm)
  (modules STM)
  (libraries qcheck domainslib))
 
 (library
  (name lin)
+ (public_name lin)
  (modules lin)
  (libraries threads qcheck))

--- a/lin.opam
+++ b/lin.opam
@@ -18,8 +18,6 @@ depends: [
 ]
 pin-depends: [
   ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
-  ["sexplib0.v0.14.0"          "git+https://github.com/patricoferris/sexplib0#5.00"]
-  ["ppxlib.0.25.0~5.00preview" "git+https://github.com/kit-ty-kate/ppxlib#500+sexp"]
 
   ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]

--- a/lin.opam
+++ b/lin.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
-synopsis:     "Experimental multicore tests"
+name:         "lin"
+synopsis:     "Experimental library for linearizability checking in Multicore"
 maintainer:   ["Jan Midtgaard <mail@janmidtgaard.dk>"]
 authors:      ["Jan Midtgaard <mail@janmidtgaard.dk>"]
 license:      "BSD-2-clause"
@@ -11,16 +12,9 @@ depends: [
   "dune"                {>= "2.9.3"}
   "ocamlfind"           {>= "1.9.3"}
   "domainslib"          {>= "0.4.0"}
-  "ppx_deriving"        {>= "5.2.1"}
-  "ounit2"              {>= "2.2.6"}
   "qcheck-core"         {>= "0.18.1"}
   "qcheck"              {>= "0.18.1"}
-  "ppx_deriving_qcheck" {>= "0.2.0"}
-  "kcas"                {>= "0.14"}
-  "lockfree"            {>= "0.13"}
   "odoc"                {with-doc}
-  "lin"                 {= version}
-  "stm"                 {= version}
 ]
 pin-depends: [
   ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
@@ -30,11 +24,6 @@ pin-depends: [
   ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
-  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
-
-  ["ocamlbuild.0.14.0"         "git+https://github.com/ocaml/ocamlbuild#master"]
-  ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
-  ["lockfree.0.13"             "git+https://github.com/ocaml-multicore/lockfree#master"]
 ]
 
 build: [

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps ws_deque_test.exe task_one_dep.exe task_more_deps.exe task_parallel.exe))
 
 (executable
@@ -18,6 +19,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1
@@ -37,6 +39,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (deps task_one_dep.exe)
  (action (run ./%{deps} --no-colors --verbose)))
 
@@ -50,6 +53,7 @@
 (rule
  (alias runtest)
  (deps task_more_deps.exe)
+ (package multicoretests)
  (action (run ./%{deps} --no-colors --verbose)))
 
 (executable
@@ -60,5 +64,6 @@
 
 ; (rule
 ;  (alias runtest)
+;  (package multicoretests)
 ;  (deps task_parallel.exe)
 ;  (action (run ./%{deps} --no-colors --verbose)))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps check_error_count.exe atomic_test.exe domain_joingraph.exe
        domain_spawntree.exe lazy_stm_test.exe lazy_lin_test.exe lin_tests.exe
        (alias neg_tests/default)
@@ -28,6 +29,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-stdout-to "atom-output.txt" (run ./atomic_test.exe --no-colors --verbose))
@@ -46,6 +48,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (deps domain_joingraph.exe)
  (action (run ./%{deps} --no-colors --verbose)))
 
@@ -59,6 +62,7 @@
 (rule
  (alias runtest)
  (deps domain_spawntree.exe)
+ (package multicoretests)
  (action (run ./%{deps} --no-colors --verbose)))
 
 
@@ -88,6 +92,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps lin_tests.exe))
 
 (env
@@ -21,6 +22,7 @@
 ; disable kcas test for now
 ; (rule
 ;  (alias runtest)
+;  (package multicoretests)
 ;  (action
 ;    (progn
 ;     (with-accepted-exit-codes 1

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps lf_list_test.exe lin_tests.exe))
 
 (executable
@@ -18,6 +19,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-stdout-to "lfl-output.txt" (run ./lf_list_test.exe --no-colors --verbose))
@@ -36,6 +38,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps ref_test.exe conclist_test.exe lin_tests.exe))
 
 (executable
@@ -18,6 +19,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1
@@ -37,6 +39,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1
@@ -56,6 +59,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
    (progn
     (with-accepted-exit-codes 1

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps lin_tests.exe))
 
 (env
@@ -20,6 +21,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
   (progn
    (with-accepted-exit-codes 1

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -3,6 +3,7 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps lin_tests.exe))
 
 (env
@@ -20,6 +21,7 @@
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (action
   (progn
    (with-accepted-exit-codes 1

--- a/stm.opam
+++ b/stm.opam
@@ -18,8 +18,6 @@ depends: [
 ]
 pin-depends: [
   ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
-  ["sexplib0.v0.14.0"          "git+https://github.com/patricoferris/sexplib0#5.00"]
-  ["ppxlib.0.25.0~5.00preview" "git+https://github.com/kit-ty-kate/ppxlib#500+sexp"]
 
   ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]

--- a/stm.opam
+++ b/stm.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+name:         "stm"
 synopsis:     "Experimental multicore tests"
 maintainer:   ["Jan Midtgaard <mail@janmidtgaard.dk>"]
 authors:      ["Jan Midtgaard <mail@janmidtgaard.dk>"]
@@ -11,16 +12,9 @@ depends: [
   "dune"                {>= "2.9.3"}
   "ocamlfind"           {>= "1.9.3"}
   "domainslib"          {>= "0.4.0"}
-  "ppx_deriving"        {>= "5.2.1"}
-  "ounit2"              {>= "2.2.6"}
   "qcheck-core"         {>= "0.18.1"}
   "qcheck"              {>= "0.18.1"}
-  "ppx_deriving_qcheck" {>= "0.2.0"}
-  "kcas"                {>= "0.14"}
-  "lockfree"            {>= "0.13"}
   "odoc"                {with-doc}
-  "lin"                 {= version}
-  "stm"                 {= version}
 ]
 pin-depends: [
   ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
@@ -30,11 +24,6 @@ pin-depends: [
   ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
-  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
-
-  ["ocamlbuild.0.14.0"         "git+https://github.com/ocaml/ocamlbuild#master"]
-  ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
-  ["lockfree.0.13"             "git+https://github.com/ocaml-multicore/lockfree#master"]
 ]
 
 build: [


### PR DESCRIPTION
This creates packages containing the `Lin` and `STM` libraries, called `lin` and `stm` respectively. It allows users to install and use these libraries in a simple way, independently of the multicoretests test suite—which is restricted to the `multicoretests` package. It also allows to install `lin` and `stm` without some dependencies of multicoretests such as ounit2, lockfree or ppx_deriving.

The package multicoretests now depends on `lin` and `stm`.