### PR TITLE
Run and print dune CI tests sequentially - not in parallel.

### DIFF
--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - run: opam exec -- dune runtest -j1 --error-reporting=deterministic

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - run: opam exec -- dune runtest -j1 --error-reporting=deterministic


### PR DESCRIPTION
`dune` builds and runs tests in parallel.
Since many of these multicore tests are heavily parallel this changes the CI to run only one test at a time (sequentially).

It also adds an error-reporting flag (in an attempt) to align the QCheck and `check_error_count` printing.