### PR TITLE
Negtest adjustments

### DIFF
--- a/src/neg_tests/CList.ml
+++ b/src/neg_tests/CList.ml
@@ -1,7 +1,6 @@
 (** a simple concurrent list - from Sadiq *)
 
-module Make (T : sig type t end) = struct
-type conc_list = { value: T.t; next: conc_list option }
+type 'a conc_list = { value: 'a; next: 'a conc_list option }
 
 let rec add_node list_head n =
   (* try to add a new node to head *)
@@ -31,5 +30,3 @@ let member list_head n =
 let add_and_check list_head n () =
   assert(add_node list_head n);
   assert(member list_head n)
-
-end

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -2,15 +2,14 @@ open QCheck
 
 (** This is a parallel test of the buggy concurrent list CList *)
 
-module CLConf (T : sig type t val dummy : t val f : int -> t val pp : t -> string end) =
+module CLConf (T : sig type t val zero : t val f : int -> t val pp : t -> string end) =
 struct
-  module CL = CList.Make (struct type t = T.t end)
   let pp_t fmt t = Format.fprintf fmt "%s" (T.pp t)
   type cmd =
-  | Add_node of (T.t [@printer pp_t])
-  | Member of (T.t [@printer pp_t]) [@@deriving show { with_path = false }]
+    | Add_node of (T.t [@printer pp_t])
+    | Member of (T.t [@printer pp_t]) [@@deriving show { with_path = false }]
   type state = T.t list
-  type sut = CL.conc_list Atomic.t
+  type sut = T.t CList.conc_list Atomic.t
 
   let arb_cmd s =
     let int_gen = fun st -> Gen.nat st |> T.f in
@@ -24,8 +23,8 @@ struct
          [ Gen.map (fun i -> Add_node i) int_gen;
 	   Gen.map (fun i -> Member i) mem_gen; ])
 
-  let init_state  = [ T.dummy ]
-  let init_sut () = CL.list_init T.dummy
+  let init_state  = [ T.zero ]
+  let init_sut () = CList.list_init T.zero
   let cleanup _   = ()
 
   let next_state c s = match c with
@@ -35,8 +34,8 @@ struct
   type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }]
 
   let run c r = match c with
-    | Add_node i -> RAdd_node (CL.add_node r i)
-    | Member i   -> RMember (CL.member r i)
+    | Add_node i -> RAdd_node (CList.add_node r i)
+    | Member i   -> RMember (CList.member r i)
 
   let precond _ _ = true
 
@@ -48,14 +47,14 @@ end
 
 module T_int = struct
   type t = int
-  let dummy = 0
+  let zero = 0
   let f i = i
   let pp = Int.to_string
 end
 
 module T_int64 = struct
   type t = int64
-  let dummy = Int64.zero
+  let zero = Int64.zero
   let f = Int64.of_int
   let pp = Int64.to_string
 end

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -7,8 +7,8 @@ struct
   module CL = CList.Make (struct type t = T.t end)
   let pp_t fmt t = Format.fprintf fmt "%s" (T.pp t)
   type cmd =
-  | Add_node of T.t [@printer pp_t]
-  | Member of T.t [@printer pp_t] [@@deriving show { with_path = false }]
+  | Add_node of (T.t [@printer pp_t])
+  | Member of (T.t [@printer pp_t]) [@@deriving show { with_path = false }]
   type state = T.t list
   type sut = CL.conc_list Atomic.t
 

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -66,8 +66,8 @@ module CLT_int64 = STM.Make(CLConf(T_int64))
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count,name = 1000,"CList test" in
-   [CLT_int.agree_test     ~count ~name;
-    CLT_int64.agree_test ~count ~name;
-    CLT_int.agree_test_par ~count ~name;
-    CLT_int64.agree_test_par ~count ~name;])
+  (let count = 1000 in
+   [CLT_int.agree_test       ~count ~name:"int CList test";
+    CLT_int64.agree_test     ~count ~name:"int64 CList test";
+    CLT_int.agree_test_par   ~count ~name:"int CList test";
+    CLT_int64.agree_test_par ~count ~name:"int64 CList test"])

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -69,5 +69,5 @@ QCheck_runner.run_tests_main
   (let count,name = 1000,"CList test" in
    [CLT_int.agree_test     ~count ~name;
     CLT_int64.agree_test ~count ~name;
-    CLT_int.agree_test ~count ~name;
+    CLT_int.agree_test_par ~count ~name;
     CLT_int64.agree_test_par ~count ~name;])

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -45,7 +45,7 @@
     (with-accepted-exit-codes 1
       (with-stdout-to "cl-output.txt" (run ./conclist_test.exe --no-colors --verbose)))
     (cat cl-output.txt)
-    (run %{bin:check_error_count} "conclist_test" 1 cl-output.txt))))
+    (run %{bin:check_error_count} "conclist_test" 2 cl-output.txt))))
 
 
 ;; Linearizability tests of ref and Clist

--- a/src/neg_tests/lin_tests.ml
+++ b/src/neg_tests/lin_tests.ml
@@ -87,11 +87,12 @@ struct
 
   type t = CL.conc_list Atomic.t
   let gen_int' st = Gen.nat st |> T.f
+  let pp_t fmt t = Format.fprintf fmt "%s" (T.pp t)
   type int' = T.t
 
   type cmd =
-    | Add_node of int' [@printer fun fmt t -> fprintf fmt "Add_node %s" (T.pp t)]
-    | Member of int' [@printer fun fmt t -> fprintf fmt "Member %s" (T.pp t)] [@@deriving qcheck, show { with_path = false }]
+    | Add_node of (int' [@printer pp_t])
+    | Member of (int' [@printer pp_t]) [@@deriving qcheck, show { with_path = false }]
 
   type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }]
 

--- a/src/neg_tests/lin_tests.ml
+++ b/src/neg_tests/lin_tests.ml
@@ -9,8 +9,8 @@ module Sut_int =
     let get r = !r
     let set r i = r:=i
     let add r i = let old = !r in r:= i + old (* buggy: not atomic *)
-    let incr r = incr r                     (* buggy: not atomic *)
-    let decr r = decr r                (* buggy: not atomic *)
+    let incr r = incr r                       (* buggy: not atomic *)
+    let decr r = decr r                       (* buggy: not atomic *)
 end
 
 module Sut_int64 =

--- a/src/neg_tests/lin_tests.ml
+++ b/src/neg_tests/lin_tests.ml
@@ -125,12 +125,12 @@ module CLT_int64 = Lin.Make(CLConf (T_int64))
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
-  RT_int.lin_test    `Domain ~count:1000 ~name:"ref int test with Domains";
-  RT_int64.lin_test    `Domain ~count:1000 ~name:"ref int64 test with Domains";
-  RT_int64.lin_test    `Thread ~count:1000 ~name:"ref int64 test with Threads";
-  CLT_int.lin_test   `Domain ~count:1000 ~name:"CList int test with Domains";
-  CLT_int.lin_test   `Thread ~count:1000 ~name:"CList int test with Threads";
-  CLT_int64.lin_test   `Domain ~count:1000 ~name:"CList test64 with Domains";
-  CLT_int64.lin_test   `Thread ~count:1000 ~name:"CList test64 with Threads";
-]
+QCheck_runner.run_tests_main
+  (let count = 1000 in
+   [RT_int.lin_test    `Domain ~count ~name:"ref int test with Domains";
+    RT_int64.lin_test  `Domain ~count ~name:"ref int64 test with Domains";
+    RT_int64.lin_test  `Thread ~count ~name:"ref int64 test with Threads";
+    CLT_int.lin_test   `Domain ~count ~name:"CList int test with Domains";
+    CLT_int.lin_test   `Thread ~count ~name:"CList int test with Threads";
+    CLT_int64.lin_test `Domain ~count ~name:"CList test64 with Domains";
+    CLT_int64.lin_test `Thread ~count ~name:"CList test64 with Threads"])

--- a/src/neg_tests/lin_tests.ml
+++ b/src/neg_tests/lin_tests.ml
@@ -128,6 +128,7 @@ Util.set_ci_printing ()
 QCheck_runner.run_tests_main
   (let count = 1000 in
    [RT_int.lin_test    `Domain ~count ~name:"ref int test with Domains";
+    RT_int.lin_test    `Thread ~count ~name:"ref int test with Threads";
     RT_int64.lin_test  `Domain ~count ~name:"ref int64 test with Domains";
     RT_int64.lin_test  `Thread ~count ~name:"ref int64 test with Threads";
     CLT_int.lin_test   `Domain ~count ~name:"CList int test with Domains";

--- a/src/neg_tests/lin_tests.ml
+++ b/src/neg_tests/lin_tests.ml
@@ -81,11 +81,9 @@ module RT_int64 = Lin.Make(RConf_int64)
 (** ********************************************************************** *)
 (**                  Tests of the buggy concurrent list CList              *)
 (** ********************************************************************** *)
-module CLConf (T : sig type t val dummy : t val f : int -> t val pp : t -> string end) =
+module CLConf (T : sig type t val zero : t val f : int -> t val pp : t -> string end) =
 struct
-  module CL = CList.Make (struct type t = T.t end)
-
-  type t = CL.conc_list Atomic.t
+  type t = T.t CList.conc_list Atomic.t
   let gen_int' st = Gen.nat st |> T.f
   let pp_t fmt t = Format.fprintf fmt "%s" (T.pp t)
   type int' = T.t
@@ -96,25 +94,25 @@ struct
 
   type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }]
 
-  let init () = CL.list_init T.dummy
+  let init () = CList.list_init T.zero
 
   let run c r = match c with
-    | Add_node i -> RAdd_node (CL.add_node r i)
-    | Member i   -> RMember (CL.member r i)
+    | Add_node i -> RAdd_node (CList.add_node r i)
+    | Member i   -> RMember (CList.member r i)
 
   let cleanup _ = ()
 end
 
 module T_int = struct
   type t = int
-  let dummy = 0
+  let zero = 0
   let f i = i
   let pp = Int.to_string
 end
 
 module T_int64 = struct
   type t = int64
-  let dummy = Int64.zero
+  let zero = Int64.zero
   let f = Int64.of_int
   let pp = Int64.to_string
 end

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -8,8 +8,8 @@ module Sut =
     let get r = !r
     let set r i = r:=i
     let add r i = let old = !r in r:=i + old (* buggy: not atomic *)
-    let incr r = incr r     (* buggy: not guaranteed to be atomic *)
-    let decr r = decr r     (* buggy: not guaranteed to be atomic *)
+    let incr r = incr r                      (* buggy: not atomic *)
+    let decr r = decr r                      (* buggy: not atomic *)
 end
 
 module RConf =

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -70,34 +70,11 @@ module RT = STM.Make(RConf)
 
 module RConfGC = STM.AddGC(RConf)
 module RTGC = STM.Make(RConfGC)
-
-let agree_prop_pargc =
-  (fun (seq_pref,cmds1,cmds2) ->
-    assume (RTGC.cmds_ok RConfGC.init_state (seq_pref@cmds1));
-    assume (RTGC.cmds_ok RConfGC.init_state (seq_pref@cmds2));
-    let sut = RConfGC.init_sut () in
-    let res = RTGC.interp_sut_res sut seq_pref in
-    let wait = Atomic.make true in
-    let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; RTGC.interp_sut_res sut cmds1) in
-    let dom2 = Domain.spawn (fun () -> Atomic.set wait false; RTGC.interp_sut_res sut cmds2) in
-    let obs1 = Domain.join dom1 in
-    let obs2 = Domain.join dom2 in
-    let res  = RTGC.check_obs res obs1 obs2 RConfGC.init_state in
-    let ()   = RConf.cleanup sut in
-    res)
-
-let agree_test_pargc ~count ~name =
-  let rep_count = 50 in
-  let seq_len,par_len = 20,15 in
-  Test.make ~count ~name
-    (RTGC.arb_cmds_par seq_len par_len)
-    (STM.repeat rep_count agree_prop_pargc)
 ;;
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count,name = 1000,"global ref test" in
-   [RT.agree_test     ~count ~name;
-    RT.agree_test_par ~count ~name;]
-   @
-   [agree_test_pargc ~count:1000 ~name:"parallel global ref test (w/repeat and AddGC functor)"])
+   [RT.agree_test       ~count ~name;
+    RT.agree_test_par   ~count ~name;
+    RTGC.agree_test_par ~count ~name:"global ref test (w/AddGC functor)"])


### PR DESCRIPTION
This PR makes a number of cosmetic changes to the neg_tests.

It also fixes a few things
 - an error count was off-by-one for conclist_test
 - the int CList STM test was run sequentially twice (but not in parallel).