### PR TITLE
Remove domainslib pin

### DIFF
--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -10,14 +10,12 @@ dev-repo:     "git+https://github.com/jmid/multicoretests.git"
 depends: [
   "base-domains"
   "dune"                {>= "2.9.3"}
-  "domainslib"          {>= "0.4.0"}
+  "domainslib"          {>= "0.4.2"}
   "qcheck-core"         {>= "0.18.1"}
   "qcheck"              {>= "0.18.1"}
   "odoc"                {with-doc}
 ]
 pin-depends: [
-  ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
-
   ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
   ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/jmid/multicoretests.git"
 depends: [
   "base-domains"
   "dune"                {>= "2.9.3"}
-  "domainslib"          {>= "0.4.0"}
+  "domainslib"          {>= "0.4.2"}
   "ppx_deriving"        {>= "5.2.1"}
   "ounit2"              {>= "2.2.6"}
   "qcheck-core"         {>= "0.18.1"}
@@ -21,7 +21,6 @@ depends: [
   "multicorecheck"      {= version}
 ]
 pin-depends: [
-  ["domainslib.0.4.0"          "git+https://github.com/ocaml-multicore/domainslib.git#master"]
   ["sexplib0.v0.14.0"          "git+https://github.com/patricoferris/sexplib0#5.00"]
   ["ppxlib.0.25.0~5.00preview" "git+https://github.com/kit-ty-kate/ppxlib#500+sexp"]
 


### PR DESCRIPTION
Move to domainslib 0.4.2
- which supports the latest trunk (renaming `Effect.t`)
- which eliminates the need to pin