### PR TITLE
Remove Domainslib from STM.ml

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,9 @@ across commands. The resulting module contains a function
 system-under-test (`sut`) across a sequential run of an arbitrary
 command sequence.
 
-`agree_test` comes in two parallel variants for now (see
-[lib/STM.ml](lib/STM.ml)):
-
- - `agree_test_par` which tests in parallel by `spawn`ing two domains
-   from `Domain` directly and
- - `agree_test_pardomlib` which tests in parallel by instead using
-   `Domainslib.Task`.
+`agree_test` comes in a parallel variant `agree_test_par`
+which tests in parallel by `spawn`ing two domains with `Domain`
+(see [lib/STM.ml](lib/STM.ml)).
 
 Repeating a non-deterministic property can currently be done in two
 different ways:

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name STM)
  (public_name multicorecheck.stm)
  (modules STM)
- (libraries qcheck domainslib util))
+ (libraries qcheck util))
 
 (library
  (name lin)

--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -10,7 +10,6 @@ dev-repo:     "git+https://github.com/jmid/multicoretests.git"
 depends: [
   "base-domains"
   "dune"                {>= "2.9.3"}
-  "domainslib"          {>= "0.4.2"}
   "qcheck-core"         {>= "0.18.1"}
   "qcheck"              {>= "0.18.1"}
   "odoc"                {with-doc}


### PR DESCRIPTION
This cleans-up the old Domainslib experiments from STM.ml
- the domainslib tests and properties are removed
- the README is updated
- the dependency is removed from lib/dune and multicorecheck.opam