### PR TITLE
Avoid double cleanup in Lin

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -84,29 +84,31 @@ module Make(Spec : CmdSpec) (*: StmTest *)
 
   let rec check_seq_cons pref cs1 cs2 seq_sut seq_trace = match pref with
     | (c,res)::pref' ->
-       res = Spec.run c seq_sut
-       && check_seq_cons pref' cs1 cs2 seq_sut (c::seq_trace)
+        if res = Spec.run c seq_sut
+        then check_seq_cons pref' cs1 cs2 seq_sut (c::seq_trace)
+        else (Spec.cleanup seq_sut; false)
+    (* Invariant: call Spec.cleanup immediately after mismatch  *)
     | [] -> match cs1,cs2 with
-            | [],[] -> true
+            | [],[] -> Spec.cleanup seq_sut; true
             | [],(c2,res2)::cs2' ->
-               res2 = Spec.run c2 seq_sut
-               && check_seq_cons pref cs1 cs2' seq_sut (c2::seq_trace)
+                if res2 = Spec.run c2 seq_sut
+                then check_seq_cons pref cs1 cs2' seq_sut (c2::seq_trace)
+                else (Spec.cleanup seq_sut; false)
             | (c1,res1)::cs1',[] ->
-               res1 = Spec.run c1 seq_sut
-               && check_seq_cons pref cs1' cs2 seq_sut (c1::seq_trace)
+                if res1 = Spec.run c1 seq_sut
+                then check_seq_cons pref cs1' cs2 seq_sut (c1::seq_trace)
+                else (Spec.cleanup seq_sut; false)
             | (c1,res1)::cs1',(c2,res2)::cs2' ->
-               (res1 = Spec.run c1 seq_sut
-                && check_seq_cons pref cs1' cs2 seq_sut (c1::seq_trace))
-               ||
-                 (* rerun to get seq_sut to same cmd branching point *)
-                 (Spec.cleanup seq_sut;
-                  let seq_sut' = Spec.init () in
-                  let _ = interp seq_sut' (List.rev seq_trace) in
-                  let b =
-                    res2 = Spec.run c2 seq_sut'
-                    && check_seq_cons pref cs1 cs2' seq_sut' (c2::seq_trace)
-                  in
-                  Spec.cleanup seq_sut'; b)
+                (if res1 = Spec.run c1 seq_sut
+                 then check_seq_cons pref cs1' cs2 seq_sut (c1::seq_trace)
+                 else (Spec.cleanup seq_sut; false))
+                ||
+                (* rerun to get seq_sut to same cmd branching point *)
+                (let seq_sut' = Spec.init () in
+                 let _ = interp seq_sut' (List.rev seq_trace) in
+                 if res2 = Spec.run c2 seq_sut'
+                 then check_seq_cons pref cs1 cs2' seq_sut' (c2::seq_trace)
+                 else (Spec.cleanup seq_sut'; false))
 
   (* Linearizability property based on [Domain] and an Atomic flag *)
   let lin_prop_domain =
@@ -120,9 +122,7 @@ module Make(Spec : CmdSpec) (*: StmTest *)
       let obs2 = Domain.join dom2 in
       let ()   = Spec.cleanup sut in
       let seq_sut = Spec.init () in
-      let b = check_seq_cons pref_obs obs1 obs2 seq_sut [] in
-      Spec.cleanup seq_sut;
-      b
+      check_seq_cons pref_obs obs1 obs2 seq_sut []
       || Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -142,9 +142,7 @@ module Make(Spec : CmdSpec) (*: StmTest *)
       Spec.cleanup sut;
       let seq_sut = Spec.init () in
       (* we reuse [check_seq_cons] to linearize and interpret sequentially *)
-      let b = check_seq_cons pref_obs !obs1 !obs2 seq_sut [] in
-      Spec.cleanup seq_sut;
-      b
+      check_seq_cons pref_obs !obs1 !obs2 seq_sut []
       || Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))

--- a/src/internal/cleanup.ml
+++ b/src/internal/cleanup.ml
@@ -1,0 +1,53 @@
+open QCheck
+
+(** This is a variant of refs to test for double cleanup *)
+
+module RConf =
+struct
+  exception Already_cleaned
+  type status = Inited | Cleaned
+
+  type cmd =
+    | Get
+    | Set of int
+    | Add of int [@@deriving show { with_path = false }]
+
+  type t = (status ref) * (int ref)
+
+  let gen_cmd =
+    let int_gen = Gen.nat in
+      (Gen.oneof
+         [Gen.return Get;
+	  Gen.map (fun i -> Set i) int_gen;
+	  Gen.map (fun i -> Add i) int_gen;
+         ])
+
+  let init () = (ref Inited, ref 0)
+
+  let cleanup (status,_) =
+    if !status = Cleaned
+    then raise Already_cleaned
+    else status := Cleaned
+
+  type res = RGet of int | RSet | RAdd [@@deriving show { with_path = false }]
+
+  let run c (_,r) = match c with
+    | Get   -> RGet (!r)
+    | Set i -> (r:=i; RSet)
+    | Add i -> (let old = !r in r := i + old; RAdd) (* buggy: not atomic *)
+end
+
+module RT = Lin.Make(RConf)
+;;
+Test.check_exn
+  (let seq_len,par_len = 20,15 in
+   Test.make ~count:1000 ~name:("avoid double cleanup test")
+     (RT.arb_cmds_par seq_len par_len)
+     (fun input ->
+        try
+          ignore (RT.lin_prop_domain input);
+          true
+        with
+        | RConf.Already_cleaned -> failwith "Already cleaned"
+        | _ -> true
+     ))

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -1,0 +1,19 @@
+;; Internal tests
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps cleanup.exe))
+
+(executable
+ (name cleanup)
+ (modules cleanup)
+ (libraries qcheck lin)
+ (preprocess (pps ppx_deriving.show)))
+
+(rule
+ (alias runtest)
+ (deps cleanup.exe)
+ (package multicoretests)
+ (action (run ./%{deps} --no-colors --verbose)))


### PR DESCRIPTION
This fixes #9.

The search for a linearization may explore multiple sequential runs, which each require an `init` and a `cleanup`.
The exploration may stop early and try another combination, which means we cannot simply `cleanup` afterwards.
Instead we call `cleanup` when the exploration of a linearization is done.