### PR TITLE
Increase reproducability of Lin Thread tests

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -145,9 +145,15 @@ module Make(Spec : CmdSpec) (*: StmTest *)
   
   (* Linearizability test based on [Domain] *)
   let lin_test ~count ~name (lib : [ `Domain | `Thread ]) =
-    let rep_count = 50 in
-    let seq_len,par_len = 20,15 in
-    let lin_prop = match lib with `Domain -> lin_prop_domain | ` Thread -> lin_prop_thread in
-    Test.make ~count ~retries:3 ~name:("Linearizable " ^ name)
-      (arb_cmds_par seq_len par_len) (repeat rep_count lin_prop)
+    match lib with
+    | `Domain ->
+        let rep_count = 50 in
+        let seq_len,par_len = 20,15 in
+        Test.make ~count ~retries:3 ~name:("Linearizable " ^ name ^ " with Domain")
+          (arb_cmds_par seq_len par_len) (repeat rep_count lin_prop_domain)
+    | `Thread ->
+        let rep_count = 50 in
+        let seq_len,par_len = 20,15 in
+        Test.make ~count ~retries:3 ~name:("Linearizable " ^ name ^ " with Thread")
+          (arb_cmds_par seq_len par_len) (repeat rep_count lin_prop_thread)
 end

--- a/src/neg_tests/domain_lin_tests.ml
+++ b/src/neg_tests/domain_lin_tests.ml
@@ -1,0 +1,13 @@
+open Lin_tests_common
+
+(** This is a driver of the negative tests over the Domain module *)
+
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main
+  (let count = 1000 in
+   [RT_int.lin_test    `Domain ~count ~name:"ref int test";
+    RT_int64.lin_test  `Domain ~count ~name:"ref int64 test";
+    CLT_int.lin_test   `Domain ~count ~name:"CList int test";
+    CLT_int64.lin_test `Domain ~count ~name:"CList test64"])

--- a/src/neg_tests/domain_lin_tests.ml
+++ b/src/neg_tests/domain_lin_tests.ml
@@ -10,4 +10,4 @@ QCheck_runner.run_tests_main
    [RT_int.lin_test    `Domain ~count ~name:"ref int test";
     RT_int64.lin_test  `Domain ~count ~name:"ref int64 test";
     CLT_int.lin_test   `Domain ~count ~name:"CList int test";
-    CLT_int64.lin_test `Domain ~count ~name:"CList test64"])
+    CLT_int64.lin_test `Domain ~count ~name:"CList int64 test"])

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -4,7 +4,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps ref_test.exe conclist_test.exe lin_tests.exe))
+ (deps ref_test.exe conclist_test.exe domain_lin_tests.exe thread_lin_tests.exe))
 
 (executable
  (name ref_test)
@@ -50,12 +50,17 @@
 
 ;; Linearizability tests of ref and Clist
 
-(executable
- (name lin_tests)
- (modules lin_tests)
- (flags (:standard -w -27))
+(library
+ (name lin_tests_common)
+ (modules lin_tests_common)
  (libraries qcheck lin CList)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+
+(executables
+ (names domain_lin_tests thread_lin_tests)
+ (modules domain_lin_tests thread_lin_tests)
+ (flags (:standard -w -27))
+ (libraries lin_tests_common))
 
 (rule
  (alias runtest)
@@ -63,6 +68,16 @@
  (action
    (progn
     (with-accepted-exit-codes 1
-      (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-    (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 5 lin-output.txt))))
+      (with-stdout-to "domain_lin-output.txt" (run ./domain_lin_tests.exe --no-colors --verbose)))
+    (cat domain_lin-output.txt)
+    (run %{bin:check_error_count} "domain_lin_tests" 4 domain_lin-output.txt))))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (action
+   (progn
+    (with-accepted-exit-codes 1
+      (with-stdout-to "thread_lin-output.txt" (run ./thread_lin_tests.exe --no-colors --verbose)))
+    (cat thread_lin-output.txt)
+    (run %{bin:check_error_count} "thread_lin_tests" 1 thread_lin-output.txt))))

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -110,17 +110,3 @@ end
 
 module CLT_int = Lin.Make(CLConf (Int))
 module CLT_int64 = Lin.Make(CLConf (Int64))
-
-;;
-Util.set_ci_printing ()
-;;
-QCheck_runner.run_tests_main
-  (let count = 1000 in
-   [RT_int.lin_test    `Domain ~count ~name:"ref int test with Domains";
-    RT_int.lin_test    `Thread ~count ~name:"ref int test with Threads";
-    RT_int64.lin_test  `Domain ~count ~name:"ref int64 test with Domains";
-    RT_int64.lin_test  `Thread ~count ~name:"ref int64 test with Threads";
-    CLT_int.lin_test   `Domain ~count ~name:"CList int test with Domains";
-    CLT_int.lin_test   `Thread ~count ~name:"CList int test with Threads";
-    CLT_int64.lin_test `Domain ~count ~name:"CList test64 with Domains";
-    CLT_int64.lin_test `Thread ~count ~name:"CList test64 with Threads"])

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -58,7 +58,7 @@ module RConf_int64 = struct
     | Add of int'
     | Incr
     | Decr [@@deriving qcheck, show { with_path = false }]
-  and int' = int64 [@gen Gen.ui64]
+  and int' = int64 [@gen Gen.(map Int64.of_int nat)]
 
   type res = RGet of int64 | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }]
 

--- a/src/neg_tests/thread_lin_tests.ml
+++ b/src/neg_tests/thread_lin_tests.ml
@@ -1,0 +1,13 @@
+open Lin_tests_common
+
+(** This is a driver of the negative tests over the Thread module *)
+
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main
+  (let count = 1000 in
+   [RT_int.lin_test    `Thread ~count ~name:"ref int test";
+    RT_int64.lin_test  `Thread ~count ~name:"ref int64 test";
+    CLT_int.lin_test   `Thread ~count ~name:"CList int test";
+    CLT_int64.lin_test `Thread ~count ~name:"CList test64"])

--- a/src/neg_tests/thread_lin_tests.ml
+++ b/src/neg_tests/thread_lin_tests.ml
@@ -10,4 +10,4 @@ QCheck_runner.run_tests_main
    [RT_int.lin_test    `Thread ~count ~name:"ref int test";
     RT_int64.lin_test  `Thread ~count ~name:"ref int64 test";
     CLT_int.lin_test   `Thread ~count ~name:"CList int test";
-    CLT_int64.lin_test `Thread ~count ~name:"CList test64"])
+    CLT_int64.lin_test `Thread ~count ~name:"CList int64 test"])


### PR DESCRIPTION
This splits the negative tests of Lin into
- Domain tests and
- Thread tests

In order to increase reproducability it then
- uses an allocating, non-tail-recursive `interp_thread` function
- delays the first thread until the second is up and running
- increases the `rep_count`

For the latter I spent a bit of time developing a statistical test to decide whether a candidate change would
constitute an improvement. I then recorded for 10.000 arbitrary `cmd`-triples whether the property would hold,
and used these numbers for a z-statistic test following https://www.itl.nist.gov/div898/handbook/prc/section3/prc33.htm
The three above changes proved to yield statistically significant increases.

Things that didn't pan out
- `Thread.delay` instead of `Thread.yield` to maximize concurrency issues
- extra `Thread.yield`s in the `Thread.create` lambdas
- ...