### PR TITLE
Count both failures and errors in check_error_count

### DIFF
--- a/src/check_error_count.ml
+++ b/src/check_error_count.ml
@@ -16,8 +16,9 @@ let check_count s = match int_of_string s with
     then print_msg_and_exit "negative count not allowed"
     else i
 
-let failure_str =
-  "--- Failure --------------------------------------------------------------------"
+let get_error_counts a =
+  let len = Array.length a in
+  Scanf.sscanf a.(len-1) "failure (%i tests failed, %i tests errored, ran %i tests)" (fun fails errors total -> (fails,errors,total))
 
 let () =
   if Array.length Sys.argv <> 4 then print_usage_and_exit ();
@@ -26,9 +27,8 @@ let () =
   match Arg.read_arg filename with
   | exception Sys_error msg -> print_msg_and_exit msg
   | content ->
-     let count =
-       Array.fold_left
-         (fun c line -> if line=failure_str then c+1 else c) 0 content in
+     let fails,errors,_total = get_error_counts content in
+     let count = fails+errors in
      if count=exp_count
      then Printf.printf "Test '%s' succeeded\n\n" testname
      else


### PR DESCRIPTION
For now, we are still using a somewhat clunky `check_error_count` to check that the number of failing test cases match the expected number. The counting program does not count QCheck errors though. 
This PR changes `check_error_count` to count both failures and errors. As a consequence, a test like the `Lazy` module that throws an exception can also be handled.