### PR TITLE
CI output adjustments, take 37

### DIFF
--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --error-reporting=deterministic
+      - run: opam exec -- dune runtest -j1 --no-buffer

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer
+      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no_buffer
+      - run: opam exec -- dune runtest -j1 --no_buffer --display=quiet

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --error-reporting=deterministic
+      - run: opam exec -- dune runtest -j1 --no_buffer

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the root of this directory):
 ```
 opam install . --deps-only --with-test
 dune build
-dune runtest -j1 --no-buffer
+dune runtest -j1 --no-buffer --display=quiet
 ```
 
 Individual tests can be run by invoking `dune exec`. For example:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the root of this directory):
 ```
 opam install . --deps-only --with-test
 dune build
-dune runtest -j1 --error-reporting=deterministic
+dune runtest -j1 --no-buffer
 ```
 
 Individual tests can be run by invoking `dune exec`. For example:

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -20,6 +20,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps ws_deque_test.exe)
  (action
   (progn
    (bash "(./ws_deque_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee wsd-output.txt")

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -21,11 +21,9 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "wsd-output.txt" (run ./ws_deque_test.exe --no-colors --verbose)))
-    (cat wsd-output.txt)
-    (run %{bin:check_error_count} "ws_deque_test" 1 wsd-output.txt))))
+  (progn
+   (bash "(./ws_deque_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee wsd-output.txt")
+   (run %{bin:check_error_count} "domainslib/ws_deque_test" 1 wsd-output.txt))))
 
 
 ;; tests of Domainslib.Task's async functionality (non-STM)

--- a/src/dune
+++ b/src/dune
@@ -30,11 +30,8 @@
 (rule
  (alias runtest)
  (package multicoretests)
- (action
-   (progn
-    (with-stdout-to "atom-output.txt" (run ./atomic_test.exe --no-colors --verbose))
-    (cat atom-output.txt)
-    (run ./check_error_count.exe "atomic_test" 0 atom-output.txt))))
+ (deps atomic_test.exe)
+ (action (run ./%{deps} --no-colors --verbose)))
 
 
 ;; tests of Domain's spawn functionality (non-STM)
@@ -94,8 +91,6 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-    (cat lin-output.txt)
-    (run ./check_error_count.exe "lin_tests" 1 lin-output.txt))))
+  (progn
+   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+   (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))

--- a/src/dune
+++ b/src/dune
@@ -90,7 +90,8 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps lin_tests.exe)
  (action
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
-   (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))
+   (run ./check_error_count.exe "lin_tests" 1 lin-output.txt))))

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -29,3 +29,13 @@
 ;       (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
 ;     (cat lin-output.txt)
 ;     (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))
+
+
+; disable kcas test for now
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (action
+;   (progn
+;    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+;    (run %{bin:check_error_count} "kcas/lin_tests" 1 lin-output.txt))))

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -23,18 +23,7 @@
 ; (rule
 ;  (alias runtest)
 ;  (package multicoretests)
-;  (action
-;    (progn
-;     (with-accepted-exit-codes 1
-;       (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-;     (cat lin-output.txt)
-;     (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))
-
-
-; disable kcas test for now
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
+;  (deps lin_tests.exe)
 ;  (action
 ;   (progn
 ;    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -20,11 +20,8 @@
 (rule
  (alias runtest)
  (package multicoretests)
- (action
-   (progn
-    (with-stdout-to "lfl-output.txt" (run ./lf_list_test.exe --no-colors --verbose))
-    (cat lfl-output.txt)
-    (run %{bin:check_error_count} "lf_list_test" 0 lfl-output.txt))))
+ (deps lf_list_test.exe)
+ (action (run ./%{deps} --no-colors --verbose)))
 
 
 ;; Linearizability tests of the lockfree library
@@ -40,8 +37,6 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-    (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 2 lin-output.txt))))
+  (progn
+   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+   (run %{bin:check_error_count} "lockfree/lin_tests" 2 lin-output.txt))))

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -36,6 +36,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps lin_tests.exe)
  (action
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -20,6 +20,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps ref_test.exe)
  (action
   (progn
    (bash "(./ref_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee ref-output.txt")
@@ -38,6 +39,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps conclist_test.exe)
  (action
   (progn
    (bash "(./conclist_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee cl-output.txt")
@@ -61,6 +63,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps domain_lin_tests.exe)
  (action
   (progn
    (bash "(./domain_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee domain-lin-output.txt")
@@ -69,6 +72,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps thread_lin_tests.exe)
  (action
   (progn
    (bash "(./thread_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee thread-lin-output.txt")

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -21,11 +21,9 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "ref-output.txt" (run ./ref_test.exe --no-colors --verbose)))
-    (cat ref-output.txt)
-    (run %{bin:check_error_count} "ref_test" 2 ref-output.txt))))
+  (progn
+   (bash "(./ref_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee ref-output.txt")
+   (run %{bin:check_error_count} "neg_tests/ref_test" 2 ref-output.txt))))
 
 (library
  (name CList)
@@ -41,11 +39,9 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "cl-output.txt" (run ./conclist_test.exe --no-colors --verbose)))
-    (cat cl-output.txt)
-    (run %{bin:check_error_count} "conclist_test" 2 cl-output.txt))))
+  (progn
+   (bash "(./conclist_test.exe --no-colors --verbose || echo 'test run triggered an error') | tee cl-output.txt")
+   (run %{bin:check_error_count} "neg_tests/conclist_test" 2 cl-output.txt))))
 
 
 ;; Linearizability tests of ref and Clist
@@ -66,18 +62,14 @@
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "domain_lin-output.txt" (run ./domain_lin_tests.exe --no-colors --verbose)))
-    (cat domain_lin-output.txt)
-    (run %{bin:check_error_count} "domain_lin_tests" 4 domain_lin-output.txt))))
+  (progn
+   (bash "(./domain_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee domain-lin-output.txt")
+   (run %{bin:check_error_count} "neg_tests/domain_lin_tests" 4 domain-lin-output.txt))))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (action
-   (progn
-    (with-accepted-exit-codes 1
-      (with-stdout-to "thread_lin-output.txt" (run ./thread_lin_tests.exe --no-colors --verbose)))
-    (cat thread_lin-output.txt)
-    (run %{bin:check_error_count} "thread_lin_tests" 1 thread_lin-output.txt))))
+  (progn
+   (bash "(./thread_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee thread-lin-output.txt")
+   (run %{bin:check_error_count} "neg_tests/thread_lin_tests" 1 thread-lin-output.txt))))

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -24,7 +24,5 @@
  (package multicoretests)
  (action
   (progn
-   (with-accepted-exit-codes 1
-    (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-   (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))
+   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+   (run %{bin:check_error_count} "queue/lin_tests" 1 lin-output.txt))))

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -22,6 +22,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps lin_tests.exe)
  (action
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -22,6 +22,7 @@
 (rule
  (alias runtest)
  (package multicoretests)
+ (deps lin_tests.exe)
  (action
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -24,7 +24,5 @@
  (package multicoretests)
  (action
   (progn
-   (with-accepted-exit-codes 1
-    (with-stdout-to "lin-output.txt" (run ./lin_tests.exe --no-colors --verbose)))
-   (cat lin-output.txt)
-    (run %{bin:check_error_count} "lin_tests" 1 lin-output.txt))))
+   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+   (run %{bin:check_error_count} "stack/lin_tests" 1 lin-output.txt))))


### PR DESCRIPTION
The test suite contains both positive tests ("things work as expected") and negative tests ("things fail as expected") which are run via GitHub Actions. 

Ideally we want test output printed for both
- a failing positive test (to see the counter example)
- a passing negative test (to confirm counter example - and its reduced size)

Furthermore, continuous (unbuffered) output is nice to follow along, confirm progress, and identify any hanging tests.

This PR achieves these
- at the price of using `dune`'s `bash`-action (which then requires us to list `deps` manually)
- avoids output-garbling if tests are run with `--display=quiet`