### PR TITLE
Add Fiber-interpretation of CmdSpec

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -31,7 +31,9 @@ module type CmdSpec = sig
   (** [run c t] should interpret the command [c] over the system under test [t] (typically side-effecting). *)
 end
 
-module Make(Spec : CmdSpec) (*: StmTest *)
+(** A functor to create Domain and Thread test setups.
+    We use it below, but it can also be used independently *)
+module MakeDomThr(Spec : CmdSpec)
   = struct
 
   (* operate over arrays to avoid needless allocation underway *)
@@ -147,18 +149,125 @@ module Make(Spec : CmdSpec) (*: StmTest *)
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))
               (pref_obs,!obs1,!obs2))
+end
 
-  (* Linearizability test based on [Domain] *)
-  let lin_test ~count ~name (lib : [ `Domain | `Thread ]) =
+
+(** A functor to create all three (Domain, Thread, and Effect) test setups.
+    The result [include]s the output module from the [MakeDomThr] functor above *)
+module Make(Spec : CmdSpec)
+= struct
+  (* Scheduler adapted from https://kcsrk.info/slides/retro_effects_simcorp.pdf *)
+  open Effect
+  open Effect.Deep
+
+  type _ t += Fork : (unit -> unit) -> unit t
+            | Yield : unit t
+
+  let enqueue k q = Queue.push k q
+  let dequeue q =
+    if Queue.is_empty q
+    then () (*Finished*)
+    else continue (Queue.pop q) ()
+
+  let start_sched main =
+    (* scheduler's queue of continuations *)
+    let q = Queue.create () in
+    let rec spawn = fun (type res) (f : unit -> res) ->
+      match_with f ()
+        { retc = (fun _v -> dequeue q); (* value case *)
+          exnc = (fun e -> print_string (Printexc.to_string e); raise e);
+          effc = (fun (type a) (e : a t) -> match e with
+              | Yield  -> Some (fun (k : (a, _) continuation) -> enqueue k q; dequeue q)
+              | Fork f -> Some (fun (k : (a, _) continuation) -> enqueue k q; spawn f)
+              | _      -> None ) }
+    in
+    spawn main
+
+  (* short hands *)
+  let fork f = perform (Fork f)
+  let yield () = perform Yield
+
+
+  (** A refined [CmdSpec] specification with generator-controlled [Yield] effects *)
+  module EffSpec
+  = struct
+
+    type t = Spec.t
+    let init = Spec.init
+    let cleanup = Spec.cleanup
+
+    type cmd = SchedYield | UserCmd of Spec.cmd [@@deriving qcheck]
+
+    let show_cmd c = match c with
+      | SchedYield -> "<SchedYield>"
+      | UserCmd c  -> Spec.show_cmd c
+
+    let gen_cmd =
+      (Gen.frequency
+         [(3,Gen.return SchedYield);
+          (5,Gen.map (fun c -> UserCmd c) Spec.gen_cmd)])
+
+    type res = SchedYieldRes | UserRes of Spec.res
+
+    let show_res c = match c with
+      | SchedYieldRes -> "<SchedYieldRes>"
+      | UserRes r     -> Spec.show_res r
+
+    let run c sut = match c with
+      | SchedYield ->
+          (yield (); SchedYieldRes)
+      | UserCmd uc ->
+          let res = Spec.run uc sut in
+          UserRes res
+  end
+
+  module EffTest = MakeDomThr(EffSpec)
+
+  let filter_res rs = List.filter (fun (c,_) -> c <> EffSpec.SchedYield) rs
+
+  (* Parallel agreement property based on effect-handler scheduler *)
+  let lin_prop_effect =
+    (fun (seq_pref,cmds1,cmds2) ->
+       let sut = Spec.init () in
+       (* exclude [Yield]s from sequential prefix *)
+       let pref_obs = EffTest.interp_thread sut (List.filter (fun c -> c <> EffSpec.SchedYield) seq_pref) in
+       let obs1,obs2 = ref [], ref [] in
+       let main () =
+         (* For now, we reuse [interp_thread] which performs useless [Thread.yield] on single-domain/fibered program *)
+         fork (fun () -> let tmp1 = EffTest.interp_thread sut cmds1 in obs1 := tmp1);
+         fork (fun () -> let tmp2 = EffTest.interp_thread sut cmds2 in obs2 := tmp2); in
+       let () = start_sched main in
+       let () = Spec.cleanup sut in
+       let seq_sut = Spec.init () in
+       (* exclude [Yield]s from sequential executions when searching for an interleaving *)
+       EffTest.check_seq_cons (filter_res pref_obs) (filter_res !obs1) (filter_res !obs2) seq_sut []
+       || Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
+       @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
+         (fun (c,r) -> Printf.sprintf "%s : %s" (EffSpec.show_cmd c) (EffSpec.show_res r))
+         (pref_obs,!obs1,!obs2))
+
+  module FirstTwo = MakeDomThr(Spec)
+  include FirstTwo
+
+  (* Linearizability test based on [Domain], [Thread], or [Effect] *)
+  let lin_test ~count ~name (lib : [ `Domain | `Thread | `Effect ]) =
     let seq_len,par_len = 20,15 in
-    let arb_cmd_triple = arb_cmds_par seq_len par_len in
     match lib with
     | `Domain ->
+        let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 50 in
         Test.make ~count ~retries:3 ~name:("Linearizable " ^ name ^ " with Domain")
           arb_cmd_triple (repeat rep_count lin_prop_domain)
     | `Thread ->
+        let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 100 in
         Test.make ~count ~retries:10 ~name:("Linearizable " ^ name ^ " with Thread")
           arb_cmd_triple (repeat rep_count lin_prop_thread)
+    | `Effect ->
+        (* this generator is over [EffSpec.cmd] including [SchedYield], not [Spec.cmd] like the above two *)
+        let arb_cmd_triple = EffTest.arb_cmds_par seq_len par_len in
+        let rep_count = 1 in
+        Test.make ~count ~retries:10 ~name:("Linearizable " ^ name ^ " with Effect")
+          arb_cmd_triple (repeat rep_count lin_prop_effect)
+
 end

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -60,6 +60,13 @@
  (flags (:standard -w -27))
  (libraries lin_tests_common))
 
+(executable
+ (name effect_lin_tests)
+ (modules effect_lin_tests)
+ (flags (:standard -w -27))
+ (libraries lin_tests_common)
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+
 (rule
  (alias runtest)
  (package multicoretests)
@@ -77,3 +84,12 @@
   (progn
    (bash "(./thread_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee thread-lin-output.txt")
    (run %{bin:check_error_count} "neg_tests/thread_lin_tests" 1 thread-lin-output.txt))))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps effect_lin_tests.exe)
+ (action
+  (progn
+   (bash "(./effect_lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee effect-lin-output.txt")
+   (run %{bin:check_error_count} "neg_tests/effect_lin_tests" 4 effect-lin-output.txt))))

--- a/src/neg_tests/effect_lin_tests.ml
+++ b/src/neg_tests/effect_lin_tests.ml
@@ -1,0 +1,26 @@
+open Lin_tests_common
+
+(** This is a driver of the negative tests over the Effect module *)
+
+(* Q: What constitutes a Fiber-unsafe API?
+   A: Tests that behave differently on each run certainly do.
+   Hack: Let's **NOT** properly reset the system-under-test between every test run to trigger a failure.
+   Warning: because of the failure to properly reproduce these counterexamples will shrink badly  *)
+module RT_int'    = Lin.Make(struct include RConf_int      let sut = init () let init () = sut end)
+module RT_int64'  = Lin.Make(struct include RConf_int64    let sut = init () let init () = sut end)
+module CLT_int'   = Lin.Make(struct include CLConf (Int)   let sut = init () let init () = sut end)
+module CLT_int64' = Lin.Make(struct include CLConf (Int64) let sut = init () let init () = sut end)
+
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main
+  (let count = 20_000 in
+   [RT_int.lin_test     `Effect ~count ~name:"ref int test";
+    RT_int64.lin_test   `Effect ~count ~name:"ref int64 test";
+    CLT_int.lin_test    `Effect ~count ~name:"CList int test";
+    CLT_int64.lin_test  `Effect ~count ~name:"CList int64 test";
+    RT_int'.lin_test    `Effect ~count ~name:"ref int test";
+    RT_int64'.lin_test  `Effect ~count ~name:"ref int64 test";
+    CLT_int'.lin_test   `Effect ~count ~name:"CList int test";
+    CLT_int64'.lin_test `Effect ~count ~name:"CList int64 test"])


### PR DESCRIPTION
This PR implements an interpretation of `CmdSpec` over fibers.

It includes a user-level scheduler based on effects adapted from
@kayceesrk's slides: https://kcsrk.info/slides/retro_effects_simcorp.pdf

With this PR we are now able to test `Domain`, `Thread`, and `Effect`
executions from the same `CmdSpec` specification (three-for-the-price-of-one!)