### PR TITLE
Reduce the number of cpu_relax calls

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -38,6 +38,9 @@ end
 module MakeDomThr(Spec : CmdSpec)
   = struct
 
+  (* plain interpreter of a cmd list *)
+  let interp_plain sut cs = List.map (fun c -> (c, Spec.run c sut)) cs
+
   (* operate over arrays to avoid needless allocation underway *)
   let interp sut cs =
     let cs_arr = Array.of_list cs in
@@ -109,7 +112,7 @@ module MakeDomThr(Spec : CmdSpec)
                 ||
                 (* rerun to get seq_sut to same cmd branching point *)
                 (let seq_sut' = Spec.init () in
-                 let _ = interp seq_sut' (List.rev seq_trace) in
+                 let _ = interp_plain seq_sut' (List.rev seq_trace) in
                  if Spec.equal_res res2 (Spec.run c2 seq_sut')
                  then check_seq_cons pref cs1 cs2' seq_sut' (c2::seq_trace)
                  else (Spec.cleanup seq_sut'; false))
@@ -118,7 +121,7 @@ module MakeDomThr(Spec : CmdSpec)
   let lin_prop_domain =
     (fun (seq_pref,cmds1,cmds2) ->
       let sut = Spec.init () in
-      let pref_obs = interp sut seq_pref in
+      let pref_obs = interp_plain sut seq_pref in
       let wait = Atomic.make true in
       let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; interp sut cmds1) in
       let dom2 = Domain.spawn (fun () -> Atomic.set wait false; interp sut cmds2) in

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -140,7 +140,7 @@ module MakeDomThr(Spec : CmdSpec)
     (fun (seq_pref, cmds1, cmds2) ->
       let sut = Spec.init () in
       let obs1, obs2 = ref [], ref [] in
-      let pref_obs = interp sut seq_pref in
+      let pref_obs = interp_plain sut seq_pref in
       let wait = ref true in
       let th1 = Thread.create (fun () -> while !wait do Thread.yield () done; obs1 := interp_thread sut cmds1) () in
       let th2 = Thread.create (fun () -> wait := false; obs2 := interp_thread sut cmds2) () in
@@ -240,7 +240,7 @@ module Make(Spec : CmdSpec)
     (fun (seq_pref,cmds1,cmds2) ->
        let sut = Spec.init () in
        (* exclude [Yield]s from sequential prefix *)
-       let pref_obs = EffTest.interp_thread sut (List.filter (fun c -> c <> EffSpec.SchedYield) seq_pref) in
+       let pref_obs = EffTest.interp_plain sut (List.filter (fun c -> c <> EffSpec.SchedYield) seq_pref) in
        let obs1,obs2 = ref [], ref [] in
        let main () =
          (* For now, we reuse [interp_thread] which performs useless [Thread.yield] on single-domain/fibered program *)


### PR DESCRIPTION
This reduces the number of unnecesary `cpu_relax` calls by introducing a plain interpreter function, `interp_plain`.

For the fun of it, I recorded 10 runs of the `Atomic` test from `src/lin_tests.ml` before and after the change.
It turns out to be a statistically significant improvement:
```
x atomic-before.dat
+ atomic-after.dat
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|             +                                                                                                                            x                                        |
|+      +  +  +   +  +      +      +         +                                                        x         x  x   x         x     x   x         x                             x|
|     |___________MA_____________|                                                                            |_____________________A__M__________________|                         |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10          11.3          13.6          12.3         12.19    0.65735159
+  10           8.3           9.6           8.8          8.85    0.38944405
Difference at 95.0% confidence
	-3.34 +/- 0.507633
	-27.3995% +/- 4.16434%
	(Student's t, pooled s = 0.540267)
```
_Edit: this is the output from running the program `ministat`_