### PR TITLE
Switch to QCheck w/splitting fun generator

### DIFF
--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -15,9 +15,9 @@ depends: [
   "odoc"                {with-doc}
 ]
 pin-depends: [
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
+  ["qcheck-core.0.18.1"        "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
+  ["qcheck-ounit.0.18.1"       "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
+  ["qcheck.0.18.1"             "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
 ]
 
 build: [

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -24,10 +24,10 @@ pin-depends: [
   ["sexplib0.v0.14.0"          "git+https://github.com/patricoferris/sexplib0#5.00"]
   ["ppxlib.0.25.0~5.00preview" "git+https://github.com/kit-ty-kate/ppxlib#500+sexp"]
 
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
-  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
+  ["qcheck-core.0.18.1"        "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
+  ["qcheck-ounit.0.18.1"       "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
+  ["qcheck.0.18.1"             "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
+  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/jmid/qcheck.git#fix-fun-gen-repro"]
 
   ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
   ["lockfree.0.13"             "git+https://github.com/ocaml-multicore/lockfree#master"]


### PR DESCRIPTION
QCheck has a bug which affects reproducability when using a function generator a part as testing a non-deterministic property:
See c-cube/qcheck#236 and c-cube/qcheck#240 for details.

This PR switches to the fixed QCheck branch (until it is merged).

_Addendum: This issue was affecting reproducability of long-running `Stack` and `Queue` tests._