### PR TITLE
Switch to branch with improved shrinkers

### DIFF
--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -15,9 +15,9 @@ depends: [
   "odoc"                {with-doc}
 ]
 pin-depends: [
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
+  ["qcheck-core.0.18.1"        "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
+  ["qcheck-ounit.0.18.1"       "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
+  ["qcheck.0.18.1"             "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
 ]
 
 build: [

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -24,10 +24,10 @@ pin-depends: [
   ["sexplib0.v0.14.0"          "git+https://github.com/patricoferris/sexplib0#5.00"]
   ["ppxlib.0.25.0~5.00preview" "git+https://github.com/kit-ty-kate/ppxlib#500+sexp"]
 
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
-  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
+  ["qcheck-core.0.18.1"        "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
+  ["qcheck-ounit.0.18.1"       "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
+  ["qcheck.0.18.1"             "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
+  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/jmid/qcheck.git#shrinker-improvements-list-string-fun"]
 
   ["domainslib.0.4.2"          "git+https://github.com/ocaml-multicore/domainslib#master"]
   ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]


### PR DESCRIPTION
This PR pins the latest QCheck shrinker improvements from c-cube/qcheck#242.
I've rebased this branch a few times and let it run on the CI without any issues.

Overall, because of the reduced number of shrink attempts I expect it to result it potentially smaller counterexamples.
If, say `repeat` and `retry` bring repeatability of an issue to 95% 
- a shrink sequence of 5 steps will succeed with 76% chance whereas
- a shrink sequence of 10 steps will succeed with 57% chance
so the fewer required steps, the better.