### PR TITLE
Reenable domainslib/task_parallel test

### DIFF
--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -29,6 +29,7 @@ pin-depends: [
   ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
   ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
 
+  ["domainslib.0.4.2"          "git+https://github.com/ocaml-multicore/domainslib#master"]
   ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
   ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]
 ]

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -40,8 +40,8 @@
  (modules task_parallel)
  (libraries util qcheck domainslib))
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps task_parallel.exe)
-;  (action (run ./%{deps} --no-colors --verbose)))
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps task_parallel.exe)
+ (action (run ./%{deps} --no-colors --verbose)))


### PR DESCRIPTION
This fixes #10.

It pin-depends the development version of domainslib until the next release containing ocaml-multicore/domainslib#67.