### PR TITLE
Fix long interleaving times

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -240,7 +240,7 @@ struct
   (* Parallel agreement test based on [Domain] and [repeat] *)
   let agree_test_par ~count ~name =
     let rep_count = 50 in
-    let seq_len,par_len = 20,15 in
+    let seq_len,par_len = 20,12 in
     Test.make ~count ~name:("parallel " ^ name ^ " (w/repeat)")
       (arb_cmds_par seq_len par_len)
       (repeat rep_count agree_prop_par)
@@ -248,14 +248,14 @@ struct
   (* Parallel agreement test based on [Domain] and [~retries] *)
   let agree_test_par_retries ~count ~name =
     let rep_count = 200 in
-    let seq_len,par_len = 20,15 in
+    let seq_len,par_len = 20,12 in
     Test.make ~retries:rep_count ~count ~name:("parallel " ^ name ^ " (w/shrink retries)")
       (arb_cmds_par seq_len par_len) agree_prop_par
 
   (* Parallel agreement test based on [Domain] which combines [repeat] and [~retries] *)
   let agree_test_par_comb ~count ~name =
     let rep_count = 15 in
-    let seq_len,par_len = 20,15 in
+    let seq_len,par_len = 20,12 in
     Test.make ~retries:15 ~count ~name:("parallel " ^ name ^ " (w/repeat-retries comb.)")
       (arb_cmds_par seq_len par_len)
       (repeat rep_count agree_prop_par) (* 15 times each, then 15 * 15 times when shrinking *)

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -261,7 +261,7 @@ module Make(Spec : CmdSpec)
 
   (* Linearizability test based on [Domain], [Thread], or [Effect] *)
   let lin_test ~count ~name (lib : [ `Domain | `Thread | `Effect ]) =
-    let seq_len,par_len = 20,15 in
+    let seq_len,par_len = 20,12 in
     match lib with
     | `Domain ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
@@ -270,8 +270,8 @@ module Make(Spec : CmdSpec)
           arb_cmd_triple (repeat rep_count lin_prop_domain)
     | `Thread ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
-        let rep_count = 100 in
-        Test.make ~count ~retries:10 ~name:("Linearizable " ^ name ^ " with Thread")
+        let rep_count = 125 in
+        Test.make ~count ~retries:5 ~name:("Linearizable " ^ name ^ " with Thread")
           arb_cmd_triple (repeat rep_count lin_prop_thread)
     | `Effect ->
         (* this generator is over [EffSpec.cmd] including [SchedYield], not [Spec.cmd] like the above two *)

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -65,8 +65,7 @@ module MakeDomThr(Spec : CmdSpec)
   	  Spec.gen_cmd >>= fun c ->
 	   gen_cmds (fuel-1) >>= fun cs ->
              return (c::cs))
-  (** A fueled command list generator.
-      Accepts a state parameter to enable state-dependent [cmd] generation. *)
+  (** A fueled command list generator. *)
 
   let gen_cmds_size size_gen = Gen.sized_size size_gen gen_cmds
 
@@ -84,9 +83,13 @@ module MakeDomThr(Spec : CmdSpec)
         (map (fun p2' -> (seq,p1,p2')) (Shrink.list (*~shrink:shrink_cmd*) p2)))
 
   let arb_cmds_par seq_len par_len =
-    let seq_pref_gen = gen_cmds_size (Gen.int_bound seq_len) in
-    let par_gen = gen_cmds_size (Gen.int_bound par_len) in
-    let gen_triple = Gen.(triple seq_pref_gen par_gen par_gen) in
+    let gen_triple =
+      Gen.(int_range 2 (2*par_len) >>= fun dbl_plen ->
+           let seq_pref_gen = gen_cmds_size (int_bound seq_len) in
+           let par_len1 = dbl_plen/2 in
+           let par_gen1 = gen_cmds_size (return par_len1) in
+           let par_gen2 = gen_cmds_size (return (dbl_plen - par_len1)) in
+           triple seq_pref_gen par_gen1 par_gen2) in
     make ~print:(print_triple_vertical Spec.show_cmd) ~shrink:shrink_triple gen_triple
 
   let rec check_seq_cons pref cs1 cs2 seq_sut seq_trace = match pref with
@@ -270,7 +273,7 @@ module Make(Spec : CmdSpec)
           arb_cmd_triple (repeat rep_count lin_prop_domain)
     | `Thread ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
-        let rep_count = 125 in
+        let rep_count = 100 in
         Test.make ~count ~retries:5 ~name:("Linearizable " ^ name ^ " with Thread")
           arb_cmd_triple (repeat rep_count lin_prop_thread)
     | `Effect ->

--- a/src/neg_tests/effect_lin_tests.ml
+++ b/src/neg_tests/effect_lin_tests.ml
@@ -15,7 +15,7 @@ module CLT_int64' = Lin.Make(struct include CLConf (Int64) let sut = init () let
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count = 20_000 in
+  (let count = 1_000 in
    [RT_int.lin_test     `Effect ~count ~name:"ref int test";
     RT_int64.lin_test   `Effect ~count ~name:"ref int64 test";
     CLT_int.lin_test    `Effect ~count ~name:"CList int test";


### PR DESCRIPTION
Investigating long running times where the following Thread test took *long* to the point of suspecting a deadlock/infinite loop (or a bug in the run-time):
```
   dune exec src/neg_tests/thread_lin_tests.exe -- -v -s 219916560
```

Because of other recent fixes enhancing reproducability, I was able to pin-point the following `cmd` triple:
```ocaml
([(Member 982); (Add_node 919); (Member 443); (Member 66); (Add_node 3); (Add_node 3); (Member 5)],
 [(Add_node 9); (Member 64); (Member 5); (Add_node 72); (Add_node 989); (Member 0); (Add_node 4); (Add_node 9); (Add_node 78); (Member 67); (Member 56); (Member 76); (Member 223); (Add_node 6); (Member 89)],
 [(Add_node 855); (Add_node 36); (Member 1); (Member 142); (Add_node 6); (Add_node 4); (Member 36); (Member 4); (Member 1); (Add_node 7); (Add_node 54); (Member 9); (Add_node 8)])
```
with a 15 and 13 element `cmd list` running in parallel and needing interleaving.

Depending on the scheduling, 50 repetitions of the above would take between 1min39sec and 15min to run - with most computation time being spent in the interleaving search. Since the interleaving is costly (exponential in input length I believe) we therefore reduce the input `cmd list` size. This brings the interleaving search time significantly down (to around 1min, worst case).

While we are at it, we similarly adjust STM's `par_len` to at most 12.