### PR TITLE
Printer fixing

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -41,7 +41,7 @@ let fork_prop_with_timeout sec p x =
      | WSIGNALED _
      | WSTOPPED _  -> false)
 
-let print_triple_vertical ?(fig_indent=10) ?(res_width=20) show (seq,cmds1,cmds2) =
+let print_triple_vertical ?(fig_indent=10) ?(res_width=20) ?(center_prefix=true) show (seq,cmds1,cmds2) =
   let seq,cmds1,cmds2 = List.(map show seq, map show cmds1, map show cmds2) in
   let max_width ss = List.fold_left max 0 (List.map String.length ss) in
   let width = List.fold_left max 0 [max_width seq; max_width cmds1; max_width cmds2] in
@@ -66,7 +66,11 @@ let print_triple_vertical ?(fig_indent=10) ?(res_width=20) show (seq,cmds1,cmds2
     | [],   c::cs -> indent (); print_par_col "" (center c); print_par_cols [] cs
     | l::ls,r::rs -> indent (); print_par_col (center l) (center r); print_par_cols ls rs in
   (* actual printing *)
-  List.iter (fun c -> indent (); print_seq_col (center c)) ([bar_cmd] @ seq @ [bar_cmd]);
+  if center_prefix
+  then
+    List.iter (fun c -> indent (); print_seq_col (center c)) ([bar_cmd] @ seq @ [bar_cmd])
+  else
+    List.iter (fun c -> indent (); print_par_col (center c) "") (bar_cmd::seq@[bar_cmd]);
   indent (); print_hoz_line ();
   print_par_cols (bar_cmd::cmds1) (bar_cmd::cmds2);
   Buffer.contents buf

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -4,7 +4,19 @@
 (alias
  (name default)
  (package multicoretests)
- (deps cleanup.exe))
+ (deps cleanup.exe util_print_test.exe))
+
+(executable
+ (name util_print_test)
+ (modules util_print_test)
+ (libraries lin))
+
+(rule
+ (alias runtest)
+ (deps util_print_test.exe)
+ (package multicoretests)
+ (action (run ./%{deps})))
+
 
 (executable
  (name cleanup)

--- a/src/internal/util_print_test.ml
+++ b/src/internal/util_print_test.ml
@@ -1,0 +1,41 @@
+type cmd = A | B | C
+
+let show_cmd c = match c with
+  | A -> "A"
+  | B -> "B"
+  | C -> "C"
+
+let print_and_check_output s res =
+  let ss = (String.split_on_char '\n' s) in
+  List.iter (fun s -> Printf.printf "\"%s\"\n%!" s) ss;
+  assert (List.equal String.equal res ss)
+
+;;
+let s1 = Util.print_triple_vertical ~fig_indent:1 show_cmd ([A],[A;B;C],[C]) in
+let res1 = [
+  "            |                   ";
+  "            A                   ";
+  "            |                   ";
+  " .---------------------.";
+  " |                     |                   ";
+  " A                     C                   ";
+  " B                                         ";
+  " C                                         ";
+  ""]
+in
+print_and_check_output s1 res1
+(*assert (List.equal String.equal res1 ss1)*)
+;;
+let s2 = Util.print_triple_vertical ~fig_indent:1 ~center_prefix:false show_cmd ([A],[A;B;C],[C]) in
+let res2 = [
+  " |                                         ";
+  " A                                         ";
+  " |                                         ";
+  " .---------------------.";
+  " |                     |                   ";
+  " A                     C                   ";
+  " B                                         ";
+  " C                                         ";
+  ""]
+in
+print_and_check_output s2 res2


### PR DESCRIPTION
This PR extends `print_triple_vertical` with an option to allow a non-centered sequential prefix.
It then updates src/lockfree/ws_deque_test.ml to use the new printer.
Finally it adds a few basic, internal tests of the printer.