### PR TITLE
Add Thread tests

### DIFF
--- a/src/domain/domain_joingraph.ml
+++ b/src/domain/domain_joingraph.ml
@@ -1,6 +1,6 @@
 (**
   Generate direct tests of the Domain module's spawn/join primitives.
-  Like [src/tast_one_dep.ml]([src/tast_one_dep.ml) it does so by generating
+  Like [src/domainslib/tast_one_dep.ml]([src/domainslib/tast_one_dep.ml) it does so by generating
   a random, acyclic dependency graph of [spawn]ed [Domain.t]s each waiting
   to [join] with its dependency.
  *)

--- a/src/dune
+++ b/src/dune
@@ -4,14 +4,15 @@
  (package multicoretests)
  (deps check_error_count.exe
        (alias neg_tests/default)
-       ;; stdlib
+       ;; stdlib, in alphabetic order
        (alias atomic/default)
+       (alias buffer/default)
        (alias domain/default)
        (alias hashtbl/default)
        (alias lazy/default)
        (alias queue/default)
        (alias stack/default)
-       (alias buffer/default)
+       (alias thread/default)
        ;; other libs
        (alias domainslib/default)
        (alias lockfree/default)

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -1,0 +1,36 @@
+;; Tests of the stdlib Domain library
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps thread_joingraph.exe thread_createtree.exe))
+
+
+;; Tests of Domain's spawn functionality (non-STM)
+
+(executable
+ (name thread_joingraph)
+ (modes native byte)
+ (modules thread_joingraph)
+ (libraries threads util qcheck)
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps thread_joingraph.exe)
+ (action (run ./%{deps} --no-colors --verbose)))
+
+(executable
+ (name thread_createtree)
+ (modes native byte)
+ (modules thread_createtree)
+ (libraries threads qcheck util)
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+
+(rule
+ (alias runtest)
+ (deps thread_createtree.exe)
+ (package multicoretests)
+ (action (run ./%{deps} --no-colors --verbose)))

--- a/src/thread/thread_createtree.ml
+++ b/src/thread/thread_createtree.ml
@@ -1,0 +1,88 @@
+(** This tests the Thread module's create/join primitives. *)
+
+let max_threads = 128 (* for now this matches the internal `Max_domain` C value *)
+(*
+ Idea: generate a series of spawn trees:
+
+                  Create
+                 / |   | \
+                /  |   |  \
+               /   |   |   \
+           Incr Create Incr Create
+                 / | \        |
+                /  |  \       |
+               /   |   \      |
+            Incr Incr Incr  Decr
+
+
+ Each tree is interpreted over Thread:
+  - [Create] call [Thread.create] for each child
+  - [Incr] and [Decr] call [Atomic.incr] and [Atomic.decr], respectively
+*)
+
+open QCheck
+
+type cmd =
+  | Incr
+  | Decr
+  (*| Join*)
+  | Create of cmd list [@@deriving show { with_path = false }]
+
+(* Counts the total number of [Create]s in a tree *)
+let rec count_creates = function
+  | Incr
+  | Decr -> 0
+  | Create cs ->
+    List.length cs + List.fold_left (+) 0 (List.map count_creates cs)
+
+let gen max_depth max_width =
+  let depth_gen = Gen.int_bound max_depth in
+  let width_gen = Gen.int_bound max_width in
+  Gen.sized_size depth_gen @@ Gen.fix (fun rgen n ->
+    match n with
+    | 0 -> Gen.oneofl [Incr;Decr]
+    | _ ->
+      Gen.oneof
+        [
+          Gen.oneofl [Incr;Decr];
+          Gen.map (fun ls -> Create ls) (Gen.list_size width_gen (rgen (n/2)))
+        ])
+
+let rec shrink_cmd = function
+  | Incr
+  | Decr -> Iter.empty
+  | Create cs ->
+    let open Iter in
+    (return Incr)
+    <+>
+    (map (fun cs' -> Create cs') (Shrink.list_elems shrink_cmd cs))
+    <+>
+    (map (fun cs' -> Create cs') (Shrink.list_spine cs))
+
+let rec interp s = function
+  | Incr -> succ s
+  | Decr -> pred s
+  | Create cs -> List.fold_left (fun s' c -> interp s' c) s cs
+
+let rec thread_interp a = function
+  | Incr -> Atomic.incr a
+  | Decr -> Atomic.decr a
+  | Create cs ->
+    let ts = List.map (fun c -> Thread.create (fun () -> thread_interp a c) ()) cs in
+    List.iter Thread.join ts
+
+let t ~max_depth ~max_width = Test.make
+    ~name:"thread_createtree - with Atomic"
+    ~count:1000
+    ~retries:100
+    (make ~print:show_cmd ~shrink:shrink_cmd (gen max_depth max_width))
+    (fun c ->
+       (*Printf.printf "creates: %i\n%!" (count_creates c);*)
+       (*Printf.printf "%s\n%!" (show_cmd c);*)
+       let a = Atomic.make 0 in
+       let () = thread_interp a c in
+       Atomic.get a = interp 0 c)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_base_runner.run_tests_main [t ~max_depth:20 ~max_width:10]

--- a/src/thread/thread_joingraph.ml
+++ b/src/thread/thread_joingraph.ml
@@ -1,0 +1,125 @@
+(**
+  Generate direct tests of the Thread module's create/join primitives.
+  Like [src/domainslib/tast_one_dep.ml]([src/domainslib/tast_one_dep.ml) it does so by generating
+  a random, acyclic dependency graph of [create]d [Thread.t]s each waiting
+  to [join] with its dependency.
+ *)
+
+open QCheck
+
+(* Generates a sparse DAG of join dependencies                        *)
+(* Each thread is represented by an array index w/at most 1 dep. each *)
+(* This example DAG
+
+     A/0 <--- B/1
+      ^.
+        \
+         `- C/2 <--- D/3
+
+   is represented as: [| None; Some 0; Some 0; Some 2 |]
+
+   Since each thread can only be joined once, A/0 is joined by B/1 (not C/2)
+*)
+let gen_deps n st =
+  let a = Array.make n None in
+  for i=1 to n-1 do
+    if Gen.bool st then a.(i) <- Some (Gen.int_bound (i-1) st)
+  done;
+  a
+
+type test_input =
+  {
+    num_threads  : int;
+    dependencies : int option array
+  } [@@deriving show { with_path = false }]
+
+let shrink_deps test_input =
+  let ls = Array.to_list test_input.dependencies in
+  let is = Shrink.list ~shrink:Shrink.(option nil) ls in
+  Iter.map
+    (fun deps ->
+       let len = List.length deps in
+       let arr = Array.of_list deps in
+       let deps = Array.mapi (fun i j_opt -> match i,j_opt with
+            | 0, _
+            | _,None -> None
+            | _,Some 0 -> Some 0
+            | _, Some j ->
+              if j<0 || j>=len || j>=i (* ensure reduced dep is valid *)
+              then Some ((j + i) mod i)
+              else Some j) arr in
+       { num_threads=len; dependencies=deps }) is
+
+let arb_deps thread_bound =
+  let gen_deps =
+    Gen.(int_bound (thread_bound-1) >>= fun num_threads ->
+         let num_threads = succ num_threads in
+         gen_deps num_threads >>= fun dependencies -> return { num_threads; dependencies }) in
+  make ~print:show_test_input ~shrink:shrink_deps gen_deps
+
+(*let thread_id id i = Printf.sprintf "(thread %i, index %i)" id i*)
+
+let is_first_with_dep i dep deps =
+  [] = List.filteri (fun j opt -> j < i && opt = Some dep) (Array.to_list deps)
+
+let build_dep_graph test_input f =
+  let rec build i thread_acc =
+    if i=test_input.num_threads
+    then List.rev thread_acc
+    else
+      let p = (match test_input.dependencies.(i) with
+          | None ->
+            Thread.create f ()
+          | Some dep ->
+            Thread.create (fun () ->
+                f();
+                if is_first_with_dep i dep test_input.dependencies
+                then
+                  let p' = List.nth thread_acc (i-1-dep) in
+                  Thread.join p';
+              ) ()) in
+      build (i+1) (p::thread_acc)
+  in
+  build 0 []
+
+(** In this first test each created thread calls [work] - and then optionally join. *)
+(* a simple work item, from ocaml/testsuite/tests/misc/takc.ml *)
+let rec tak x y z =
+  if x > y then tak (tak (x-1) y z) (tak (y-1) z x) (tak (z-1) x y)
+  else z
+
+let work () =
+  for _ = 1 to 100 do
+    assert (7 = tak 18 12 6);
+  done
+
+let test_tak_work ~thread_bound =
+  Test.make ~name:"Thread.create/join - tak work" ~count:100
+    (arb_deps thread_bound)
+    ((*Util.fork_prop_with_timeout 30*)
+    (fun test_input ->
+      (*Printf.printf "%s\n%!" (show_test_input test_input);*)
+      let ps = build_dep_graph test_input work in
+      List.iteri (fun i p -> if not (Array.mem (Some i) test_input.dependencies) then Thread.join p) ps;
+      true))
+
+(** In this test each created thread calls [Atomic.incr] - and then optionally join. *)
+let test_atomic_work ~thread_bound =
+  Test.make ~name:"Thread.create/join - atomic" ~count:500
+    (arb_deps thread_bound)
+    (fun test_input ->
+       let a = Atomic.make 0 in
+       let ps = build_dep_graph test_input (fun () -> Atomic.incr a) in
+       List.iteri (fun i p ->
+           if not (Array.mem (Some i) test_input.dependencies)
+           then
+             Thread.join p;
+         ) ps;
+       Atomic.get a = test_input.num_threads)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_base_runner.run_tests_main
+  [test_tak_work    ~thread_bound:100(*8*);
+   test_atomic_work ~thread_bound:250(*8*)
+  ]


### PR DESCRIPTION
This PR adds initial tests of `Thread.create`/`join` mirroring the approach of the `Domain.spawn`/`join` tests from src/domain.