### PR TITLE
Wrap domain functions in a handler to ensure proper joining

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -236,22 +236,23 @@ struct
     make ~print:(print_triple_vertical Spec.show_cmd) ~shrink:shrink_triple gen_triple
 
   (* Parallel agreement property based on [Domain] *)
-  let agree_prop_par =
-    (fun (seq_pref,cmds1,cmds2) ->
-      assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
-      let sut = Spec.init_sut () in
-      let pref_obs = interp_sut_res sut seq_pref in
-      let wait = Atomic.make true in
-      let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; interp_sut_res sut cmds1) in
-      let dom2 = Domain.spawn (fun () -> Atomic.set wait false; interp_sut_res sut cmds2) in
-      let obs1 = Domain.join dom1 in
-      let obs2 = Domain.join dom2 in
-      let ()   = Spec.cleanup sut in
-      check_obs pref_obs obs1 obs2 Spec.init_state
+  let agree_prop_par (seq_pref,cmds1,cmds2) =
+    assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+    let sut = Spec.init_sut () in
+    let pref_obs = interp_sut_res sut seq_pref in
+    let wait = Atomic.make true in
+    let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; try Ok (interp_sut_res sut cmds1) with exn -> Error exn) in
+    let dom2 = Domain.spawn (fun () -> Atomic.set wait false; try Ok (interp_sut_res sut cmds2) with exn -> Error exn) in
+    let obs1 = Domain.join dom1 in
+    let obs2 = Domain.join dom2 in
+    let obs1 = match obs1 with Ok v -> v | Error exn -> raise exn in
+    let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
+    let ()   = Spec.cleanup sut in
+    check_obs pref_obs obs1 obs2 Spec.init_state
       || Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
-              (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))
-              (pref_obs,obs1,obs2))
+           (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))
+           (pref_obs,obs1,obs2)
 
   (* Parallel agreement test based on [Domain] which combines [repeat] and [~retries] *)
   let agree_test_par ~count ~name =


### PR DESCRIPTION
When the first domain function raises an exception, we risk not joining the second domain. This is bad for reproducability. 
Furthermore, unjoined underlying pthreads at exit can apparently cause crashes on Windows (not good either...).
We fix this by wrapping the function bodies in an exception handler and reraising an exception in the "root domain".

Thanks to @patricoferris for pointing this out :pray: