### PR TITLE
Initial Hashtbl port to DSL

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -20,6 +20,7 @@ let print_char c   = "'" ^ (QCheck.Print.char c) ^ "'"
 let print_string s = "\"" ^ (QCheck.Print.string s) ^ "\""
 let unit =           GenDeconstr (QCheck.unit,           QCheck.Print.unit, (=))
 let bool =           GenDeconstr (QCheck.bool,           QCheck.Print.bool, (=))
+let nat_small =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
 let int =            GenDeconstr (QCheck.int,            QCheck.Print.int,  (=))
 let int_small =      GenDeconstr (QCheck.small_int,      QCheck.Print.int,  (=))
 let char =           GenDeconstr (QCheck.char,           print_char,        (=))

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -9,6 +9,7 @@ type (_, _, _, _) ty
 
 val unit : (unit, 'a, 'b, combinable) ty
 val bool : (bool, 'a, 'b, combinable) ty
+val nat_small : (int, 'a, 'b, combinable) ty
 val int : (int, 'a, 'b, combinable) ty
 val int_small : (int, 'a, 'b, combinable) ty
 val char : (char, 'a, 'b, combinable) ty

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -27,3 +27,10 @@
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
    (run %{bin:check_error_count} "hashtbl/lin_tests" 1 lin-output.txt))))
+
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ ;(package multicoretests)
+ (libraries multicorecheck.lin))

--- a/src/hashtbl/lin_tests_dsl.ml
+++ b/src/hashtbl/lin_tests_dsl.ml
@@ -1,0 +1,32 @@
+(* ********************************************************************** *)
+(*                      Tests of thread-unsafe [Hashtbl]                  *)
+(* ********************************************************************** *)
+module HConf (*: Lin_api.ApiSpec*) =
+struct
+  type t = (char, int) Hashtbl.t
+
+  let init () = Hashtbl.create ~random:false 42
+  let cleanup _ = ()
+
+  open Lin_api
+  let int,char = nat_small,char_printable
+  let api =
+    [ val_ "Hashtbl.clear"    Hashtbl.clear    (t @-> returning unit);
+      val_ "Hashtbl.add"      Hashtbl.add      (t @-> char @-> int @-> returning unit);
+      val_ "Hashtbl.remove"   Hashtbl.remove   (t @-> char @-> returning unit);
+      val_ "Hashtbl.find"     Hashtbl.find     (t @-> char @-> returning_or_exc int);
+      val_ "Hashtbl.find_opt" Hashtbl.find_opt (t @-> char @-> returning (option int));
+      val_ "Hashtbl.find_all" Hashtbl.find_all (t @-> char @-> returning (list int));
+      val_ "Hashtbl.replace"  Hashtbl.replace  (t @-> char @-> int @-> returning unit);
+      val_ "Hashtbl.mem"      Hashtbl.mem      (t @-> char @-> returning bool);
+      val_ "Hashtbl.length"   Hashtbl.length   (t @-> returning int);
+    ]
+end
+
+module HT = Lin_api.Make(HConf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+  HT.lin_test     `Domain ~count:1000 ~name:"Hashtbl DSL test";
+]


### PR DESCRIPTION
This is an initial port of the `Hashtbl` example to the signature DSL. 
I used this as an illustration at the Tarides presentation on Friday.
It adds `nat_small` to the DSL as part of the PR.