### PR TITLE
Switch to opam alpha repositories

### DIFF
--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -21,7 +21,7 @@ jobs:
           ocaml-compiler: ocaml-variants.5.0.0+trunk
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
-            ocaml-beta-repository: https://github.com/ocaml/ocaml-beta-repository.git
+            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -21,7 +21,7 @@ jobs:
           ocaml-compiler: ocaml-variants.5.0.0+trunk
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
-            ocaml-beta-repository: https://github.com/ocaml/ocaml-beta-repository.git
+            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
 
       - run: opam install . --deps-only --with-test


### PR DESCRIPTION
This PR switches GitHub actions to the opam alpha repository.