### PR TITLE
Lazy STM exception wrapping

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -81,3 +81,4 @@ let protect (f : 'a -> 'b) (a : 'a) : ('b, exn) result =
 
 let pp_exn fmt e = Format.fprintf fmt "%s" (Printexc.to_string e)
 let show_exn e = Format.asprintf "%a" e pp_exn
+let equal_exn = (=)


### PR DESCRIPTION
Following the wrapping with exception handlers in #75 I just noticed that the STM tests were missing similar wrapping.
A bonus commit in the PR adds a definition for `equal_exn` to `Util` to help `deriving eq`.