### PR TITLE
First attempt to reduce boilerplate with type res

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -8,24 +8,30 @@ module Res = struct
   type 'a ty = ..
 
   type _ ty +=
-    Unit : unit ty
-  | Bool : bool ty
-  | Int : int ty
-  | Int64 : int64 ty
-  | Exn : exn ty
-  | Option : 'a ty -> 'a option ty
-  | Result : 'a ty * 'b ty -> ('a, 'b) result ty
-  | List : 'a ty -> 'a list ty
+    | Unit : unit ty
+    | Bool : bool ty
+    | Char : char ty
+    | Int : int ty
+    | Int64 : int64 ty
+    | String : string ty
+    | Bytes : bytes ty
+    | Exn : exn ty
+    | Option : 'a ty -> 'a option ty
+    | Result : 'a ty * 'b ty -> ('a, 'b) result ty
+    | List : 'a ty -> 'a list ty
 
   type 'a ty_show = 'a ty * ('a -> string)
 
+  let unit = (Unit, fun () -> "()")
   let bool = (Bool, string_of_bool)
+  let char = (Char, QCheck.Print.char)
   let int = (Int, string_of_int)
   let int64 = (Int64, Int64.to_string)
+  let string = (String, QCheck.Print.string)
+  let bytes = (Bytes, fun b -> QCheck.Print.string (Bytes.to_string b))
   let option spec =
     let (ty,show) = spec in
     (Option ty, QCheck.Print.option show)
-  let unit = (Unit, fun () -> "()")
   let exn = (Exn, Printexc.to_string)
 
   let show_result show_ok show_err = function

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -12,6 +12,7 @@ module Res = struct
     | Bool : bool ty
     | Char : char ty
     | Int : int ty
+    | Int32 : int32 ty
     | Int64 : int64 ty
     | String : string ty
     | Bytes : bytes ty
@@ -26,6 +27,7 @@ module Res = struct
   let bool = (Bool, string_of_bool)
   let char = (Char, QCheck.Print.char)
   let int = (Int, string_of_int)
+  let int32 = (Int32, Int32.to_string)
   let int64 = (Int64, Int64.to_string)
   let string = (String, QCheck.Print.string)
   let bytes = (Bytes, fun b -> QCheck.Print.string (Bytes.to_string b))

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -7,24 +7,26 @@ include Util
 module Res = struct
   type 'a ty = ..
 
-  type _ ty += Unit : unit ty
-  type _ ty += Bool : bool ty
-  type _ ty += Int : int ty
-  type _ ty += Option : 'a ty -> 'a option ty
-  type _ ty += Result : 'a ty * 'b ty -> ('a, 'b) result ty
-  type _ ty += List : 'a ty -> 'a list ty
+  type _ ty +=
+    Unit : unit ty
+  | Bool : bool ty
+  | Int : int ty
+  | Int64 : int64 ty
+  | Exn : exn ty
+  | Option : 'a ty -> 'a option ty
+  | Result : 'a ty * 'b ty -> ('a, 'b) result ty
+  | List : 'a ty -> 'a list ty
 
   type 'a ty_show = 'a ty * ('a -> string)
 
   let bool = (Bool, string_of_bool)
-
   let int = (Int, string_of_int)
-
+  let int64 = (Int64, Int64.to_string)
   let option spec =
     let (ty,show) = spec in
     (Option ty, QCheck.Print.option show)
-
   let unit = (Unit, fun () -> "()")
+  let exn = (Exn, Printexc.to_string)
 
   let show_result show_ok show_err = function
     | Ok x    -> Printf.sprintf "Ok (%s)" (show_ok x)
@@ -34,7 +36,6 @@ module Res = struct
     let (ty_ok, show_ok) = spec_ok in
     let (ty_err, show_err) = spec_err in
     (Result (ty_ok, ty_err), show_result show_ok show_err)
-
   let list spec =
     let (ty,show) = spec in
     (List ty, QCheck.Print.list show)

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -14,6 +14,7 @@ module Res = struct
     | Int : int ty
     | Int32 : int32 ty
     | Int64 : int64 ty
+    | Float : float ty
     | String : string ty
     | Bytes : bytes ty
     | Exn : exn ty
@@ -29,6 +30,7 @@ module Res = struct
   let int = (Int, string_of_int)
   let int32 = (Int32, Int32.to_string)
   let int64 = (Int64, Int64.to_string)
+  let float = (Float, Float.to_string)
   let string = (String, QCheck.Print.string)
   let bytes = (Bytes, fun b -> QCheck.Print.string (Bytes.to_string b))
   let option spec =

--- a/src/atomic/atomic_test.ml
+++ b/src/atomic/atomic_test.ml
@@ -54,14 +54,14 @@ struct
     | Incr                     -> Res (unit, Atomic.incr r)
     | Decr                     -> Res (unit, Atomic.decr r)
 
-  let postcond c s res =
+  let postcond c (s : state) res =
     let open STM.Res in
     match c,res with
-    | Get,             Res ((Int,_),v)  -> Int.equal v s (*&& v<>42*) (*an injected bug*)
+    | Get,             Res ((Int,_),v)  -> v = s (*&& v<>42*) (*an injected bug*)
     | Set _,           Res ((Unit,_),_) -> true
-    | Exchange _,      Res ((Int,_),v)  -> Int.equal v s
-    | Fetch_and_add _, Res ((Int,_),v)  -> Int.equal v s
-    | Compare_and_set (seen,_), Res ((Bool,_),b) -> Bool.equal b (s=seen)
+    | Exchange _,      Res ((Int,_),v)  -> v = s
+    | Fetch_and_add _, Res ((Int,_),v)  -> v = s
+    | Compare_and_set (seen,_), Res ((Bool,_),b) -> b = (s=seen)
     | Incr,            Res ((Unit,_),_) -> true
     | Decr,            Res ((Unit,_),_) -> true
     | _,_ -> false

--- a/src/atomic/atomic_test.ml
+++ b/src/atomic/atomic_test.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 
 (** This is a parallel test of the Atomic module *)
 
@@ -44,7 +45,6 @@ struct
   let precond _ _ = true
 
   let run c r =
-    let open STM.Res in
     match c with
     | Get                      -> Res (int,  Atomic.get r)
     | Set i                    -> Res (unit, Atomic.set r i)
@@ -55,7 +55,6 @@ struct
     | Decr                     -> Res (unit, Atomic.decr r)
 
   let postcond c (s : state) res =
-    let open STM.Res in
     match c,res with
     | Get,             Res ((Int,_),v)  -> v = s (*&& v<>42*) (*an injected bug*)
     | Set _,           Res ((Unit,_),_) -> true

--- a/src/buffer/buffer_stm_test.ml
+++ b/src/buffer/buffer_stm_test.ml
@@ -26,21 +26,22 @@ struct
   type sut = Buffer.t
 
   let arb_cmd s =
+    let int_gen,string_gen = Gen.(small_nat,small_string) in
     QCheck.make ~print:show_cmd
-      (Gen.oneof [Gen.return Contents;
-                  Gen.return To_bytes;
-                  Gen.map2 (fun off len -> Sub (off, len)) Gen.small_nat Gen.small_nat;
-                  Gen.map (fun i -> Nth i) Gen.small_nat;
-                  Gen.return Length;
-                  Gen.return Clear;
-                  Gen.return Reset;
-                  Gen.map (fun c -> Add_char c) Gen.char;
-                  Gen.map (fun s -> Add_string s) (Gen.small_string);
-                  Gen.map (fun b -> Add_bytes (String.to_bytes b)) (Gen.string);
-                  Gen.map (fun i -> Truncate i) (let len = List.length s in
+      Gen.(oneof [return Contents;
+                  return To_bytes;
+                  map2 (fun off len -> Sub (off, len)) int_gen int_gen;
+                  map (fun i -> Nth i) int_gen;
+                  return Length;
+                  return Clear;
+                  return Reset;
+                  map (fun c -> Add_char c) char;
+                  map (fun s -> Add_string s) string_gen;
+                  map (fun b -> Add_bytes (String.to_bytes b)) string_gen;
+                  map (fun i -> Truncate i) (let len = List.length s in
                                                  if len = 0
-                                                 then Gen.return 0
-                                                 else Gen.int_bound (len - 1));
+                                                 then return 0
+                                                 else int_bound (len - 1));
                  ])
 
   let init_state  = []

--- a/src/buffer/buffer_stm_test.ml
+++ b/src/buffer/buffer_stm_test.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 open Util
 
 (** parallel STM tests of Buffer *)
@@ -81,8 +82,6 @@ struct
   let precond c s = match c with
     | Truncate i -> i >= 0 && i <= List.length s
     | _ -> true
-
-  open STM.Res
 
   let run c b = match c with
     | Contents        -> Res (string, Buffer.contents b)

--- a/src/buffer/buffer_stm_test.ml
+++ b/src/buffer/buffer_stm_test.ml
@@ -35,7 +35,7 @@ struct
                   Gen.return Clear;
                   Gen.return Reset;
                   Gen.map (fun c -> Add_char c) Gen.char;
-                  Gen.map (fun s -> Add_string s) (Gen.string);
+                  Gen.map (fun s -> Add_string s) (Gen.small_string);
                   Gen.map (fun b -> Add_bytes (String.to_bytes b)) (Gen.string);
                   Gen.map (fun i -> Truncate i) (let len = List.length s in
                                                  if len = 0
@@ -55,7 +55,6 @@ struct
                     |> List.map (fun c -> Printf.sprintf "%c" c)
                     |> String.concat ""
 
-  (* changed *)
   let next_state c s = match c with
     | Contents -> s
     | To_bytes -> s
@@ -82,53 +81,39 @@ struct
     | Truncate i -> i >= 0 && i <= List.length s
     | _ -> true
 
-  (* added *)
-  type res =
-    | RContent of string
-    | RTo_bytes of bytes
-    | RSub of (string, exn) result
-    | RNth of (char, exn) result
-    | RLength of int
-    | RClear
-    | RReset
-    | RAdd_char
-    | RAdd_string
-    | RAdd_bytes
-    | RTruncate of (unit, exn) result [@@deriving show { with_path = false }]
+  open STM.Res
 
-  (* changed *)
   let run c b = match c with
-    | Contents        -> RContent (Buffer.contents b)
-    | To_bytes        -> RTo_bytes (Buffer.to_bytes b)
-    | Sub (off, len)  -> RSub (Util.protect (Buffer.sub b off) len)
-    | Nth i           -> RNth (Util.protect (Buffer.nth b) i)
-    | Length          -> RLength (Buffer.length b)
-    | Clear           -> Buffer.clear b; RClear
-    | Reset           -> Buffer.reset b; RReset
-    | Add_char ch     -> Buffer.add_char b ch; RAdd_char
-    | Add_string str  -> Buffer.add_string b str; RAdd_string
-    | Add_bytes bytes -> Buffer.add_bytes b bytes; RAdd_bytes
-    | Truncate i      -> RTruncate (Util.protect (Buffer.truncate b) i)
+    | Contents        -> Res (string, Buffer.contents b)
+    | To_bytes        -> Res (bytes,  Buffer.to_bytes b)
+    | Sub (off, len)  -> Res (result string exn, protect (Buffer.sub b off) len)
+    | Nth i           -> Res (result char exn, protect (Buffer.nth b) i)
+    | Length          -> Res (int, Buffer.length b)
+    | Clear           -> Res (unit, Buffer.clear b)
+    | Reset           -> Res (unit, Buffer.reset b)
+    | Add_char ch     -> Res (unit, Buffer.add_char b ch)
+    | Add_string str  -> Res (unit, Buffer.add_string b str)
+    | Add_bytes bytes -> Res (unit, Buffer.add_bytes b bytes)
+    | Truncate i      -> Res (result unit exn, protect (Buffer.truncate b) i)
 
-  (* added *)
   let postcond c s res = match c, res with
-    | Contents, RContent str    -> explode str = List.rev s
-    | To_bytes, RTo_bytes bytes -> bytes = (Bytes.of_string (to_string s))
-    | Sub (off, len), RSub str  ->
+    | Contents, Res ((String,_),str)   -> explode str = List.rev s
+    | To_bytes, Res ((Bytes,_), bytes) -> bytes = Bytes.of_string (to_string s)
+    | Sub (off, len), Res ((Result (String,Exn),_), str) ->
        if off > List.length s || off + len > List.length s
        then str = Error (Invalid_argument "Buffer.sub")
        else str = Ok (String.sub (to_string s) off len)
-    | Nth i, RNth r ->
+    | Nth i, Res ((Result (Char,Exn),_), r) ->
        if i < 0 || i >= List.length s
        then r = Error (Invalid_argument "Buffer.nth")
        else r = Ok (List.nth (List.rev s) i)
-    | Length, RLength i         -> i = List.length s
-    | Clear, RClear             -> true
-    | Reset, RReset             -> true
-    | Add_char _, RAdd_char     -> true
-    | Add_string _, RAdd_string -> true
-    | Add_bytes _, RAdd_bytes   -> true
-    | Truncate i, RTruncate r   ->
+    | Length, Res ((Int,_),i) -> i = List.length s
+    | Clear, Res ((Unit,_),_) -> true
+    | Reset, Res ((Unit,_),_) -> true
+    | Add_char _, Res ((Unit,_),_)   -> true
+    | Add_string _, Res ((Unit,_),_) -> true
+    | Add_bytes _, Res ((Unit,_),_)  -> true
+    | Truncate i, Res ((Result (Unit,Exn),_),r) ->
        if i < 0 || i > List.length s
        then r = Error (Invalid_argument "Buffer.truncate")
        else r = Ok ()

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -1,5 +1,12 @@
 ;; Test of the buffer library
 
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps buffer_stm_test.exe))
+
+
 (env
  (_
   (binaries

--- a/src/domainslib/chan_tests.ml
+++ b/src/domainslib/chan_tests.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 open Domainslib
 
 (** This is a parallel test of Domainslib.Chan *)
@@ -51,8 +52,6 @@ struct
     | Recv,   [] -> false
     | Send _, _  -> List.length s < capacity
     | _,      _  -> true
-
-  open STM.Res
 
   let run c chan =
     match c with

--- a/src/domainslib/chan_tests.ml
+++ b/src/domainslib/chan_tests.ml
@@ -52,20 +52,20 @@ struct
     | Send _, _  -> List.length s < capacity
     | _,      _  -> true
 
-  type res = RSend | RSend_poll of bool | RRecv of int | RRecv_poll of int option [@@deriving show { with_path = false }]
+  open STM.Res
 
   let run c chan =
     match c with
-    | Send i       -> (Chan.send chan i; RSend)
-    | Send_poll i  -> RSend_poll (Chan.send_poll chan i)
-    | Recv         -> RRecv (Chan.recv chan)
-    | Recv_poll    -> RRecv_poll (Chan.recv_poll chan)
+    | Send i       -> Res (unit, Chan.send chan i)
+    | Send_poll i  -> Res (bool, Chan.send_poll chan i)
+    | Recv         -> Res (int, Chan.recv chan)
+    | Recv_poll    -> Res (option int, Chan.recv_poll chan)
 
   let postcond c s res = match c,res with
-    | Send _,      RSend          -> (List.length s < capacity)
-    | Send_poll _, RSend_poll res -> res = (List.length s < capacity)
-    | Recv,        RRecv res      -> (match s with [] -> false | res'::_ -> res=res')
-    | Recv_poll,   RRecv_poll opt -> (match s with [] -> None | res'::_ -> Some res') = opt
+    | Send _,      Res ((Unit,_),_) -> (List.length s < capacity)
+    | Send_poll _, Res ((Bool,_),res) -> res = (List.length s < capacity)
+    | Recv,        Res ((Int,_),res) -> (match s with [] -> false | res'::_ -> Int.equal res res')
+    | Recv_poll,   Res ((Option Int,_),opt) -> (match s with [] -> None | res'::_ -> Some res') = opt
     | _,_ -> false
 end
 

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -4,7 +4,11 @@
 (alias
  (name default)
  (package multicoretests)
- (deps task_one_dep.exe task_more_deps.exe task_parallel.exe))
+ (deps
+   chan_tests.exe
+   task_one_dep.exe
+   task_more_deps.exe
+   task_parallel.exe))
 
 ;; tests of Domainslib.Task's async functionality (non-STM)
 

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -4,7 +4,10 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe))
+ (deps
+   stm_test.exe
+   lin_tests.exe
+   lin_tests_dsl.exe))
 
 (env
  (_

--- a/src/hashtbl/stm_test.ml
+++ b/src/hashtbl/stm_test.ml
@@ -1,5 +1,5 @@
 open QCheck
-open Util
+open STM
 
 (** parallel STM tests of Hashtbl *)
 
@@ -79,7 +79,6 @@ struct
     | Length        -> s
 
   let run c h =
-    let open STM.Res in
     match c with
     | Clear         -> Res (unit, Hashtbl.clear h)
     | Add (k,v)     -> Res (unit, Hashtbl.add h k v)
@@ -95,7 +94,6 @@ struct
 
   let precond _ _ = true
   let postcond c (s : state) res =
-    let open STM.Res in
     match c,res with
     | Clear,         Res ((Unit,_),_)
     | Add (_,_),     Res ((Unit,_),_)

--- a/src/hashtbl/stm_test.ml
+++ b/src/hashtbl/stm_test.ml
@@ -45,10 +45,6 @@ struct
     | Mem of char
     | Length [@@deriving show { with_path = false }]
 
-  type _ STM.Res.ty += Exn : exn STM.Res.ty
-
-  let exn : exn STM.Res.ty_show = (Exn, Printexc.to_string)
-
   let init_sut () = Hashtbl.create ~random:false 42
   let cleanup _ = ()
 

--- a/src/hashtbl/stm_test.ml
+++ b/src/hashtbl/stm_test.ml
@@ -45,16 +45,9 @@ struct
     | Mem of char
     | Length [@@deriving show { with_path = false }]
 
-  type res =
-    | RClear
-    | RAdd
-    | RRemove
-    | RFind of (int, exn) result
-    | RFind_opt of int option
-    | RFind_all of int list
-    | RReplace
-    | RMem of bool
-    | RLength of int [@@deriving show { with_path = false }]
+  type _ STM.Res.ty += Exn : exn STM.Res.ty
+
+  let exn : exn STM.Res.ty_show = (Exn, Printexc.to_string)
 
   let init_sut () = Hashtbl.create ~random:false 42
   let cleanup _ = ()
@@ -89,27 +82,34 @@ struct
     | Mem _
     | Length        -> s
 
-  let run c h = match c with
-    | Clear         -> Hashtbl.clear h; RClear
-    | Add (k,v)     -> Hashtbl.add h k v; RAdd
-    | Remove k      -> Hashtbl.remove h k; RRemove
-    | Find k        -> RFind (protect (Hashtbl.find h) k)
-    | Find_opt k    -> RFind_opt (Hashtbl.find_opt h k)
-    | Find_all k    -> RFind_all (Hashtbl.find_all h k)
-    | Replace (k,v) -> Hashtbl.replace h k v; RReplace
-    | Mem k         -> RMem (Hashtbl.mem h k)
-    | Length        -> RLength (Hashtbl.length h)
+  let run c h =
+    let open STM.Res in
+    match c with
+    | Clear         -> Res (unit, Hashtbl.clear h)
+    | Add (k,v)     -> Res (unit, Hashtbl.add h k v)
+    | Remove k      -> Res (unit, Hashtbl.remove h k)
+    | Find k        -> Res (result int exn, protect (Hashtbl.find h) k)
+    | Find_opt k    -> Res (option int, Hashtbl.find_opt h k)
+    | Find_all k    -> Res (list int, Hashtbl.find_all h k)
+    | Replace (k,v) -> Res (unit, Hashtbl.replace h k v)
+    | Mem k         -> Res (bool, Hashtbl.mem h k)
+    | Length        -> Res (int, Hashtbl.length h)
 
   let init_state  = []
 
   let precond _ _ = true
-  let postcond c s res = match c,res with
-    | Clear,         RClear
-    | Add (_,_),     RAdd
-    | Remove _,      RRemove -> true
-    | Find k,        RFind r -> r = (try Ok (List.assoc k s) with Not_found -> Error Not_found)
-    | Find_opt k,    RFind_opt r -> r = List.assoc_opt k s
-    | Find_all k,    RFind_all r ->
+  let postcond c s res =
+    let open STM.Res in
+    match c,res with
+    | Clear,         Res ((Unit,_),_)
+    | Add (_,_),     Res ((Unit,_),_)
+    | Replace (_,_), Res ((Unit,_),_) -> true
+    | Remove _,      Res ((Unit,_),_) -> true
+    | Find k,        Res ((Result (Int,Exn),_),r) ->
+        r = (try (Ok (List.assoc k s) : (int,exn) result)
+             with Not_found -> Error Not_found)
+    | Find_opt k,    Res ((Option Int,_),r) -> r = List.assoc_opt k s
+    | Find_all k,    Res ((List Int,_),r) ->
         let rec find_all h = match h with
           | [] -> []
           | (k',v')::h' ->
@@ -117,9 +117,8 @@ struct
               then v'::find_all h'
               else find_all h' in
         r = find_all s
-    | Replace (_,_), RReplace -> true
-    | Mem k,         RMem r   -> r = List.mem_assoc k s
-    | Length,        RLength r -> r = List.length s
+    | Mem k,         Res ((Bool,_),r) -> r = List.mem_assoc k s
+    | Length,        Res ((Int,_),r) -> r = List.length s
     | _ -> false
 end
 

--- a/src/hashtbl/stm_test.ml
+++ b/src/hashtbl/stm_test.ml
@@ -94,7 +94,7 @@ struct
   let init_state  = []
 
   let precond _ _ = true
-  let postcond c s res =
+  let postcond c (s : state) res =
     let open STM.Res in
     match c,res with
     | Clear,         Res ((Unit,_),_)
@@ -102,7 +102,7 @@ struct
     | Replace (_,_), Res ((Unit,_),_) -> true
     | Remove _,      Res ((Unit,_),_) -> true
     | Find k,        Res ((Result (Int,Exn),_),r) ->
-        r = (try (Ok (List.assoc k s) : (int,exn) result)
+        r = (try Ok (List.assoc k s)
              with Not_found -> Error Not_found)
     | Find_opt k,    Res ((Option Int,_),r) -> r = List.assoc_opt k s
     | Find_all k,    Res ((List Int,_),r) ->

--- a/src/lazy/lazy_stm_test.ml
+++ b/src/lazy/lazy_stm_test.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 
 (** parallel STM tests of Lazy *)
 
@@ -74,7 +75,6 @@ struct
   *)
 
   let run c l =
-    let open STM.Res in
     match c with
     | Force               -> Res (result int exn, Util.protect Lazy.force l)
     | Force_val           -> Res (result int exn, Util.protect Lazy.force_val l)
@@ -87,7 +87,6 @@ struct
                              with exn -> Error exn) (*we force the "new lazy"*)
 
   let postcond c (s : state) res =
-    let open STM.Res in
     match c,res with
     | (Force|Force_val),
       Res ((Result (Int,Exn), _), v) -> v = Ok (fst s)

--- a/src/lazy/lazy_stm_test.ml
+++ b/src/lazy/lazy_stm_test.ml
@@ -86,14 +86,14 @@ struct
         Res (result int exn, try Ok (Lazy.force (Lazy.map_val f l))
                              with exn -> Error exn) (*we force the "new lazy"*)
 
-  let postcond c s res =
+  let postcond c (s : state) res =
     let open STM.Res in
     match c,res with
     | (Force|Force_val),
-      Res ((Result (Int,Exn), _), v) -> (v : (int,exn) result) = Ok (fst s)
-    | Is_val,       Res ((Bool,_),r) -> (r : bool) = snd s
+      Res ((Result (Int,Exn), _), v) -> v = Ok (fst s)
+    | Is_val,       Res ((Bool,_),r) -> r = snd s
     | (Map (Fun (_,f)) | Map_val (Fun (_,f))),
-      Res ((Result (Int,Exn), _), i) -> (i : (int,exn) result) = Ok (f (fst s))
+      Res ((Result (Int,Exn), _), i) -> i = Ok (f (fst s))
     | _,_ -> false
 end
 

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -40,8 +40,6 @@ struct
 
   let precond _ _ = true
 
-  open STM.Res
-
   let run c d = match c with
     | Push i   -> Res (unit, Ws_deque.M.push d i)
     | Pop      -> Res (result int exn, protect Ws_deque.M.pop d)
@@ -87,7 +85,7 @@ let agree_prop_par =
     let () = WSDConf.cleanup sut in
     res ||
       Test.fail_reportf "  Results incompatible with linearized model:\n\n%s"
-      @@ Util.print_triple_vertical ~center_prefix:false Res.show
+      @@ Util.print_triple_vertical ~center_prefix:false show_res
            (List.map snd pref_obs,
             List.map snd own_obs,
             List.map snd stealer_obs))

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -5,17 +5,6 @@ open STM
 
 module Ws_deque = Lockfree.Ws_deque
 
-(* a simple work item, from ocaml/testsuite/tests/misc/takc.ml *)
-(*
-let rec tak x y z =
-  if x > y then tak (tak (x-1) y z) (tak (y-1) z x) (tak (z-1) x y)
-           else z
-
-let work () =
-  for _ = 1 to 200 do
-    assert (7 = tak 18 12 6);
-  done
- *)
 module WSDConf =
 struct
   type cmd =
@@ -51,21 +40,23 @@ struct
 
   let precond _ _ = true
 
-  type res =
-    | RPush
-    | RPop of (int, exn) result
-    | RSteal of (int, exn) result [@@deriving show { with_path = false }]
+  open STM.Res
 
   let run c d = match c with
-    | Push i   -> (Ws_deque.M.push d i; RPush)
-    | Pop      -> RPop (Util.protect Ws_deque.M.pop d)
-    | Steal    -> RSteal (Util.protect Ws_deque.M.steal d)
+    | Push i   -> Res (unit, Ws_deque.M.push d i)
+    | Pop      -> Res (result int exn, protect Ws_deque.M.pop d)
+    | Steal    -> Res (result int exn, protect Ws_deque.M.steal d)
 
   let postcond c s res = match c,res with
-    | Push _,   RPush       -> true
-    | Pop,      RPop res    -> (*Printf.printf "pop:%s %!" (match opt with None -> "None" | Some i -> string_of_int i);*)
-                               (match s with | [] -> res = Error Exit | j::_ -> res = Ok j)
-    | Steal,    RSteal res  -> (match List.rev s with | [] -> Result.is_error res | j::_ -> res = Ok j)
+    | Push _, Res ((Unit,_),_) -> true
+    | Pop,    Res ((Result (Int,Exn),_),res) ->
+        (match s with
+         | []   -> res = Error Exit
+         | j::_ -> res = Ok (j : int))
+    | Steal,  Res ((Result (Int,Exn),_),res) ->
+        (match List.rev s with
+         | []   -> Result.is_error res
+         | j::_ -> res = Ok j)
     | _,_ -> false
 end
 
@@ -96,7 +87,7 @@ let agree_prop_par =
     let () = WSDConf.cleanup sut in
     res ||
       Test.fail_reportf "  Results incompatible with linearized model:\n\n%s"
-      @@ Util.print_triple_vertical ~center_prefix:false WSDConf.show_res
+      @@ Util.print_triple_vertical ~center_prefix:false Res.show
            (List.map snd pref_obs,
             List.map snd own_obs,
             List.map snd stealer_obs))

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -47,12 +47,12 @@ struct
     | Pop      -> Res (result int exn, protect Ws_deque.M.pop d)
     | Steal    -> Res (result int exn, protect Ws_deque.M.steal d)
 
-  let postcond c s res = match c,res with
+  let postcond c (s : state) res = match c,res with
     | Push _, Res ((Unit,_),_) -> true
     | Pop,    Res ((Result (Int,Exn),_),res) ->
         (match s with
          | []   -> res = Error Exit
-         | j::_ -> res = Ok (j : int))
+         | j::_ -> res = Ok j)
     | Steal,  Res ((Result (Int,Exn),_),res) ->
         (match List.rev s with
          | []   -> Result.is_error res

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 
 (** This is a parallel test of the buggy concurrent list CList *)
 
@@ -30,8 +31,6 @@ struct
   let next_state c s = match c with
     | Add_node i -> i::s
     | Member _i  -> s
-
-  open STM.Res
 
   let run c r = match c with
     | Add_node i -> Res (bool, CList.add_node r i)

--- a/src/neg_tests/conclist_test.ml
+++ b/src/neg_tests/conclist_test.ml
@@ -31,17 +31,17 @@ struct
     | Add_node i -> i::s
     | Member _i  -> s
 
-  type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }]
+  open STM.Res
 
   let run c r = match c with
-    | Add_node i -> RAdd_node (CList.add_node r i)
-    | Member i   -> RMember (CList.member r i)
+    | Add_node i -> Res (bool, CList.add_node r i)
+    | Member i   -> Res (bool, CList.member r i)
 
   let precond _ _ = true
 
   let postcond c s res = match c,res with
-    | Add_node _, RAdd_node v -> v = true
-    | Member i,   RMember v   -> v = List.mem i s
+    | Add_node _, Res ((Bool,_),v) -> v = true
+    | Member i,   Res ((Bool,_),v) -> v = List.mem i s
     | _,_ -> false
 end
 

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -4,7 +4,12 @@
 (alias
  (name default)
  (package multicoretests)
- (deps ref_test.exe conclist_test.exe domain_lin_tests.exe thread_lin_tests.exe))
+ (deps
+   ref_test.exe
+   conclist_test.exe
+   domain_lin_tests.exe
+   thread_lin_tests.exe
+   effect_lin_tests.exe))
 
 (executable
  (name ref_test)

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -60,7 +60,7 @@ struct
   let run c r =
     let open STM.Res in
     match c with
-    | Get   -> Res (int, Sut_int.get r)
+    | Get   -> Res (int,  Sut_int.get r)
     | Set i -> Res (unit, Sut_int.set r i)
     | Add i -> Res (unit, Sut_int.add r i)
     | Incr  -> Res (unit, Sut_int.incr r)
@@ -69,11 +69,11 @@ struct
   let postcond c s res =
     let open STM.Res in
     match c,res with
-    | Get, Res ((Int,_),v) -> (v : int) = s (*&& v<>42*) (*an injected bug*)
+    | Get,   Res ((Int,_),v)  -> (v : int) = s (*&& v<>42*) (*an injected bug*)
     | Set _, Res ((Unit,_),_) -> true
     | Add _, Res ((Unit,_),_) -> true
-    | Incr, Res ((Unit,_),_) -> true
-    | Decr, Res ((Unit,_),_) -> true
+    | Incr,  Res ((Unit,_),_) -> true
+    | Decr,  Res ((Unit,_),_) -> true
     | _,_ -> false
 end
 
@@ -124,11 +124,11 @@ struct
   let postcond c s res =
     let open STM.Res in
     match c,res with
-    | Get, Res ((Int64,_),(v:int64)) -> v = s (*&& v<>42L*) (*an injected bug*)
+    | Get,   Res ((Int64,_),(v:int64)) -> v = s (*&& v<>42L*) (*an injected bug*)
     | Set _, Res ((Unit,_),_) -> true
     | Add _, Res ((Unit,_),_) -> true
-    | Incr, Res ((Unit,_),_) -> true
-    | Decr, Res ((Unit,_),_) -> true
+    | Incr,  Res ((Unit,_),_) -> true
+    | Decr,  Res ((Unit,_),_) -> true
     | _,_ -> false
 end
 

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -66,10 +66,10 @@ struct
     | Incr  -> Res (unit, Sut_int.incr r)
     | Decr  -> Res (unit, Sut_int.decr r)
 
-  let postcond c s res =
+  let postcond c (s : state) res =
     let open STM.Res in
     match c,res with
-    | Get,   Res ((Int,_),v)  -> (v : int) = s (*&& v<>42*) (*an injected bug*)
+    | Get,   Res ((Int,_),v)  -> v = s (*&& v<>42*) (*an injected bug*)
     | Set _, Res ((Unit,_),_) -> true
     | Add _, Res ((Unit,_),_) -> true
     | Incr,  Res ((Unit,_),_) -> true

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -1,4 +1,5 @@
 open QCheck
+open STM
 
 (** This is a parallel test of refs *)
 
@@ -58,7 +59,6 @@ struct
   let precond _ _ = true
 
   let run c r =
-    let open STM.Res in
     match c with
     | Get   -> Res (int,  Sut_int.get r)
     | Set i -> Res (unit, Sut_int.set r i)
@@ -67,7 +67,6 @@ struct
     | Decr  -> Res (unit, Sut_int.decr r)
 
   let postcond c (s : state) res =
-    let open STM.Res in
     match c,res with
     | Get,   Res ((Int,_),v)  -> v = s (*&& v<>42*) (*an injected bug*)
     | Set _, Res ((Unit,_),_) -> true
@@ -113,7 +112,6 @@ struct
   let precond _ _ = true
 
   let run c r =
-    let open STM.Res in
     match c with
     | Get   -> Res (int64, Sut_int64.get r)
     | Set i -> Res (unit, Sut_int64.set r i)
@@ -122,7 +120,6 @@ struct
     | Decr  -> Res (unit, Sut_int64.decr r)
 
   let postcond c s res =
-    let open STM.Res in
     match c,res with
     | Get,   Res ((Int64,_),(v:int64)) -> v = s (*&& v<>42L*) (*an injected bug*)
     | Set _, Res ((Unit,_),_) -> true

--- a/src/neg_tests/ref_test.ml
+++ b/src/neg_tests/ref_test.ml
@@ -57,21 +57,23 @@ struct
 
   let precond _ _ = true
 
-  type res = RGet of int | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }]
+  let run c r =
+    let open STM.Res in
+    match c with
+    | Get   -> Res (int, Sut_int.get r)
+    | Set i -> Res (unit, Sut_int.set r i)
+    | Add i -> Res (unit, Sut_int.add r i)
+    | Incr  -> Res (unit, Sut_int.incr r)
+    | Decr  -> Res (unit, Sut_int.decr r)
 
-  let run c r = match c with
-    | Get   -> RGet (Sut_int.get r)
-    | Set i -> (Sut_int.set r i; RSet)
-    | Add i -> (Sut_int.add r i; RAdd)
-    | Incr  -> (Sut_int.incr r; RIncr)
-    | Decr  -> (Sut_int.decr r; RDecr)
-
-  let postcond c s res = match c,res with
-    | Get, RGet v -> v = s (*&& v<>42*) (*an injected bug*)
-    | Set _, RSet -> true
-    | Add _, RAdd -> true
-    | Incr, RIncr -> true
-    | Decr, RDecr -> true
+  let postcond c s res =
+    let open STM.Res in
+    match c,res with
+    | Get, Res ((Int,_),v) -> (v : int) = s (*&& v<>42*) (*an injected bug*)
+    | Set _, Res ((Unit,_),_) -> true
+    | Add _, Res ((Unit,_),_) -> true
+    | Incr, Res ((Unit,_),_) -> true
+    | Decr, Res ((Unit,_),_) -> true
     | _,_ -> false
 end
 
@@ -110,21 +112,23 @@ struct
 
   let precond _ _ = true
 
-  type res = RGet of int64 | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }]
+  let run c r =
+    let open STM.Res in
+    match c with
+    | Get   -> Res (int64, Sut_int64.get r)
+    | Set i -> Res (unit, Sut_int64.set r i)
+    | Add i -> Res (unit, Sut_int64.add r i)
+    | Incr  -> Res (unit, Sut_int64.incr r)
+    | Decr  -> Res (unit, Sut_int64.decr r)
 
-  let run c r = match c with
-    | Get   -> RGet (Sut_int64.get r)
-    | Set i -> (Sut_int64.set r i; RSet)
-    | Add i -> (Sut_int64.add r i; RAdd)
-    | Incr  -> (Sut_int64.incr r; RIncr)
-    | Decr  -> (Sut_int64.decr r; RDecr)
-
-  let postcond c s res = match c,res with
-    | Get, RGet v -> v = s (*&& v<>42L*) (*an injected bug*)
-    | Set _, RSet -> true
-    | Add _, RAdd -> true
-    | Incr, RIncr -> true
-    | Decr, RDecr -> true
+  let postcond c s res =
+    let open STM.Res in
+    match c,res with
+    | Get, Res ((Int64,_),(v:int64)) -> v = s (*&& v<>42L*) (*an injected bug*)
+    | Set _, Res ((Unit,_),_) -> true
+    | Add _, Res ((Unit,_),_) -> true
+    | Incr, Res ((Unit,_),_) -> true
+    | Decr, Res ((Unit,_),_) -> true
     | _,_ -> false
 end
 


### PR DESCRIPTION
This is a first attempt to reduce the boilerplate associated with type `res` when defining STM tests. To see what would change concretely for the STM user, one must look at file `src/hashtbl/stm_test.ml`.

For the sake of the example, the possibility of returning values of type `exn` is not implemented in STM, and the test writer had to extend it. This is done by adding a constructor to the extensible type `'a STM.Res.ty`, and specifying how results of this type should be compared and printed.

A value of type `res` is constructed as `Res (spec, v)` where `spec` is a “type specification” which identifies the type of the result and contains the comparison and printing functions, and `v` is a value. For convenience, STM provides combinators to construct type specifications.

Finally, in `postcond`, instead of matching over the constructors of `res`, the test writer has to match over the possible result types.