### PR TITLE
Add int32 and float combinators to lin_api

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -28,6 +28,7 @@ let char_printable = GenDeconstr (QCheck.printable_char, print_char,        (=))
 let string =         GenDeconstr (QCheck.string,         print_string,      String.equal)
 let pos_int =        GenDeconstr (QCheck.pos_int,        QCheck.Print.int,  (=))
 let small_nat =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
+let int32 =          GenDeconstr (QCheck.int32,          Int32.to_string,   Int32.equal)
 let int64 =          GenDeconstr (QCheck.int64,          Int64.to_string,   Int64.equal)
 
 let option : type a c s. ?ratio:float -> (a, c, s, combinable) ty -> (a option, c, s, combinable) ty =

--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -30,6 +30,7 @@ let pos_int =        GenDeconstr (QCheck.pos_int,        QCheck.Print.int,  (=))
 let small_nat =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
 let int32 =          GenDeconstr (QCheck.int32,          Int32.to_string,   Int32.equal)
 let int64 =          GenDeconstr (QCheck.int64,          Int64.to_string,   Int64.equal)
+let float =          GenDeconstr (QCheck.float,          Float.to_string,   Float.equal)
 
 let option : type a c s. ?ratio:float -> (a, c, s, combinable) ty -> (a option, c, s, combinable) ty =
   fun ?ratio ty ->

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -17,6 +17,7 @@ val char_printable : (char, 'a, 'b, combinable) ty
 val string : (String.t, 'a, 'b, combinable) ty
 val pos_int : (int, 'a, 'b, combinable) ty
 val small_nat : (int, 'a, 'b, combinable) ty
+val int32 : (Int32.t, 'a, 'b, combinable) ty
 val int64 : (Int64.t, 'a, 'b, combinable) ty
 val option :
   ?ratio:float ->

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -19,6 +19,7 @@ val pos_int : (int, 'a, 'b, combinable) ty
 val small_nat : (int, 'a, 'b, combinable) ty
 val int32 : (Int32.t, 'a, 'b, combinable) ty
 val int64 : (Int64.t, 'a, 'b, combinable) ty
+val float : (float, 'a, 'b, combinable) ty
 val option :
   ?ratio:float ->
   ('a, 'c, 's, combinable) ty -> ('a option, 'c, 's, combinable) ty


### PR DESCRIPTION
This PR adds `int32` and `float` combinators which were missing from `lin_api.ml`

