### PR TITLE
Lin shrinking of `cmd` arguments

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -191,8 +191,9 @@ module MakeCmd (ApiSpec : ApiSpec) : Lin.CmdSpec = struct
 
   let gen_cmd : cmd QCheck.Gen.t = QCheck.Gen.frequency api
 
-
   let show_cmd (Cmd (_,args,_,print,_)) = print args
+
+  let shrink_cmd = QCheck.Shrink.nil (*FIXME*)
 
   (* Unsafe if called on two [res] whose internal values are of different
      types. *)

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -17,6 +17,8 @@ struct
     | Decr [@@deriving qcheck, show { with_path = false }]
   and int' = int [@gen Gen.nat]
 
+  let shrink_cmd = Shrink.nil
+
   type res =
     | RGet of int
     | RSet
@@ -57,6 +59,8 @@ struct
     | Decr of var [@@deriving qcheck, show { with_path = false }]
   and int' = int [@gen Gen.nat]
   and var  = int [@gen Gen.int_bound 2]
+
+  let shrink_cmd = Shrink.nil
 
   type res =
     | RGet of int

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -21,6 +21,23 @@ struct
   and int' = int [@gen Gen.nat]
   and char' = char [@gen Gen.printable]
 
+  let shrink_cmd c = match c with
+    | Clear -> Iter.empty
+    | Add (c,i) ->
+        Iter.((map (fun c -> Add (c,i)) (Shrink.char c))
+              <+>
+              (map (fun i -> Add (c,i)) (Shrink.int i)))
+    | Remove c -> Iter.map (fun c -> Remove c) (Shrink.char c)
+    | Find c -> Iter.map (fun c -> Find c) (Shrink.char c)
+    | Find_opt c -> Iter.map (fun c -> Find_opt c) (Shrink.char c)
+    | Find_all c -> Iter.map (fun c -> Find_all c) (Shrink.char c)
+    | Replace (c,i) ->
+        Iter.((map (fun c -> Replace (c,i)) (Shrink.char c))
+              <+>
+              (map (fun i -> Replace (c,i)) (Shrink.int i)))
+    | Mem c -> Iter.map (fun c -> Mem c) (Shrink.char c)
+    | Length -> Iter.empty
+
   type res =
     | RClear
     | RAdd

--- a/src/internal/cleanup.ml
+++ b/src/internal/cleanup.ml
@@ -22,6 +22,8 @@ struct
 	  Gen.map (fun i -> Add i) int_gen;
          ])
 
+  let shrink_cmd = Shrink.nil
+
   let init () = (ref Inited, ref 0)
 
   let cleanup (status,_) =

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -17,7 +17,7 @@
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck lin kcas)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; disable kcas test for now
 ; (rule

--- a/src/kcas/lin_tests.ml
+++ b/src/kcas/lin_tests.ml
@@ -20,6 +20,8 @@ struct
     | Decr [@@deriving qcheck, show { with_path = false }]
   and int' = (int [@gen Gen.nat])
 
+  let shrink_cmd = Shrink.nil
+
   type res =
     | RGet of int
     | RSet
@@ -29,7 +31,7 @@ struct
     | RMapNone of int cas_result
     | RMapSome of int cas_result
     | RIncr
-    | RDecr [@@deriving show { with_path = false }]
+    | RDecr [@@deriving show { with_path = false }, eq]
   and 'a cas_result
     = 'a Kcas.cas_result =
     | Aborted
@@ -73,6 +75,8 @@ struct
     | Decr [@@deriving qcheck, show { with_path = false }]
   and int' = (int [@gen Gen.nat])
 
+  let shrink_cmd = Shrink.nil
+
   type res =
     | RGet of int
     | RSet
@@ -82,7 +86,7 @@ struct
     | RMapNone of int cas_result
     | RMapSome of int cas_result
     | RIncr
-    | RDecr [@@deriving show { with_path = false }]
+    | RDecr [@@deriving show { with_path = false }, eq]
   and 'a cas_result
     = 'a Kcas.cas_result =
     | Aborted

--- a/src/lazy/lazy_lin_test.ml
+++ b/src/lazy/lazy_lin_test.ml
@@ -41,6 +41,17 @@ struct
     | Map_val of int_fun [@@deriving qcheck, show { with_path = false }]
   and int_fun = (int -> int) fun_ [@gen (fun1 Observable.int small_nat).gen][@printer fun fmt f -> fprintf fmt "%s" (Fn.print f)]
 
+  (*
+  let shrink_cmd c = match c with
+    | Force
+    | Force_val
+    | Is_val -> Iter.empty
+    | Map f -> Iter.map (fun f -> Map f) (Fn.shrink f)
+    | Map_val f -> Iter.map (fun f -> Map_val f) (Fn.shrink f)
+  *)
+  (* the Lazy tests already take a while to run - so better avoid spending extra time shrinking *)
+  let shrink_cmd = Shrink.nil
+
   type t = int Lazy.t
 
   let cleanup _ = ()

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -19,6 +19,21 @@ module Spec =
     and int' = int [@gen Gen.nat]
     and fct = (int -> int -> int) fun_ [@printer fun fmt f -> fprintf fmt "%s" (Fn.print f)] [@gen (fun2 Observable.int Observable.int small_int).gen]
 
+    let shrink_cmd c = match c with
+      | Take
+      | Take_opt
+      | Peek
+      | Peek_opt
+      | Clear
+      | Is_empty
+      | Length -> Iter.empty
+      | Add i -> Iter.map (fun i -> Add i) (Shrink.int i)
+      | Fold (f,i) ->
+          Iter.(
+            (map (fun f -> Fold (f,i)) (Fn.shrink f))
+            <+>
+            (map (fun i -> Fold (f,i)) (Shrink.int i)))
+
     type res =
       | RAdd
       | RTake of ((int, exn) result [@equal (=)])

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -19,6 +19,21 @@ module Spec =
     and int' = int [@gen Gen.nat]
     and fct = (int -> int -> int) fun_ [@printer fun fmt f -> fprintf fmt "%s" (Fn.print f)] [@gen (fun2 Observable.int Observable.int small_int).gen]
 
+    let shrink_cmd c = match c with
+      | Pop
+      | Pop_opt
+      | Top
+      | Top_opt
+      | Clear
+      | Is_empty
+      | Length -> Iter.empty
+      | Push i -> Iter.map (fun i -> Push i) (Shrink.int i)
+      | Fold (f,i) ->
+          Iter.(
+            (map (fun f -> Fold (f,i)) (Fn.shrink f))
+            <+>
+            (map (fun i -> Fold (f,i)) (Shrink.int i)))
+
     type res =
       | RPush
       | RPop of ((int, exn) result [@equal (=)])


### PR DESCRIPTION
This PR adds shrinking of `cmd` arguments for `Lin` in both "non-DSL mode" and in "DSL mode".

We do so by adding an entry to the interface `val shrink_cmd : cmd Shrink.t`.
For non-DSL mode, this can be trivially satisfied with `Shrink.nil` performing no shrinking.

The PR adds shrinkers to the existing non-DSL tests - except for `Lazy` (where testing and shrinking is already dog-slow).

The DSL mode has me on thinner ice. It was nevertheless instructive to better understand the DSL code base.
@OlivierNicole if you have ideas to avoid the ugly "this-should-not-happen" `failwith`s I'm all ears! :grin: 

I noticed QCheck's `char arbitrary` doesn't shrink so I include a work-around. I'll send a QCheck PR to fix it shortly.

This should take care of the `Lin`-part of #65 - the `STM`-part remains.

Finally here is a shrink output for show:
```
Messages for test Linearizable Hashtbl DSL test with Domain:

  Results incompatible with sequential execution

                                      |                    
                        Hashtbl.replace t 'a' 0  : ()      
                                      |                    
                   .------------------------------------.
                   |                                    |                    
       Hashtbl.add t 'a' 0  : ()              Hashtbl.clear t  : ()          
                                              Hashtbl.length t  : 2
```

