### PR TITLE
Fix string, bytes, and char printing

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -30,8 +30,8 @@ let int = (Int, string_of_int)
 let int32 = (Int32, Int32.to_string)
 let int64 = (Int64, Int64.to_string)
 let float = (Float, Float.to_string)
-let string = (String, QCheck.Print.string)
-let bytes = (Bytes, fun b -> QCheck.Print.string (Bytes.to_string b))
+let string = (String, fun s -> Printf.sprintf "%S" s)
+let bytes = (Bytes, fun b -> Printf.sprintf "%S" (Bytes.to_string b))
 let option spec =
   let (ty,show) = spec in
   (Option ty, QCheck.Print.option show)

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -25,7 +25,7 @@ type 'a ty_show = 'a ty * ('a -> string)
 
 let unit = (Unit, fun () -> "()")
 let bool = (Bool, string_of_bool)
-let char = (Char, QCheck.Print.char)
+let char = (Char, fun c -> Printf.sprintf "%C" c)
 let int = (Int, string_of_int)
 let int32 = (Int32, Int32.to_string)
 let int64 = (Int64, Int64.to_string)

--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -16,8 +16,8 @@ let wrap_print : type a. (a -> string) option -> (a -> string) = function
   | None -> fun _ -> "???"
   | Some f -> f
 
-let print_char c   = "'" ^ (QCheck.Print.char c) ^ "'"
-let print_string s = "\"" ^ (QCheck.Print.string s) ^ "\""
+let print_char c   = Printf.sprintf "%C" c
+let print_string s = Printf.sprintf "%S" s
 let unit =           GenDeconstr (QCheck.unit,           QCheck.Print.unit, (=))
 let bool =           GenDeconstr (QCheck.bool,           QCheck.Print.bool, (=))
 let nat_small =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))


### PR DESCRIPTION
This PR fixes printing of `string`s, `bytes`, and `char`s:
- in STM they were neither escaped, nor wrapped in quotes in the shared `res` printers
- in Lin `string` and `char` arguments were not escaped  (it is still missing bytes ATM)