### PR TITLE
Port old Lin tests to combinator DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ the last call should return `2`:
  let res2 = Hashtbl.length t;;
 ```
 
-See [test/lin_api.ml](test/lin_api.ml) for another example of testing
+See [src/atomic/lin_tests_dsl.ml](src/atomic/lin_tests_dsl.ml) for another example of testing
 the `Atomic` module.
 
 

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -7,6 +7,10 @@ type noncombinable
 
 type (_, _, _, _) ty
 
+val gen : 'a QCheck.arbitrary -> ('a -> string) -> ('a, constructible, 's, combinable) ty
+val deconstructible : ('a -> string) -> ('a -> 'a -> bool) -> ('a, deconstructible, 's, combinable) ty
+val gen_deconstructible : 'a QCheck.arbitrary -> ('a -> string) -> ('a -> 'a -> bool) -> ('a, 'c, 's, combinable) ty
+
 val unit : (unit, 'a, 'b, combinable) ty
 val bool : (bool, 'a, 'b, combinable) ty
 val char : (char, 'a, 'b, combinable) ty
@@ -39,6 +43,9 @@ val or_exn :
 
 (** Given a description of type ['a], print a value of type ['a]. *)
 val print : ('a, 'c, 's, 'comb) ty -> 'a -> string
+
+(** Given a description of type ['a], compare two values of type ['a]. *)
+val equal : ('a, deconstructible, 's, 'comb) ty -> 'a -> 'a -> bool
 
 
 (** {1 Values representing API functions} *)

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -4,7 +4,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps stm_tests.exe lin_tests.exe))
+ (deps stm_tests.exe lin_tests.exe lin_tests_dsl.exe))
 
 
 ;; STM test of Atomic
@@ -31,8 +31,19 @@
  (libraries qcheck lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests.exe)
+;  (action (run ./%{deps} --no-colors --verbose)))
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ (libraries multicorecheck.lin))
+
 (rule
  (alias runtest)
  (package multicoretests)
- (deps lin_tests.exe)
+ (deps lin_tests_dsl.exe)
  (action (run ./%{deps} --no-colors --verbose)))

--- a/src/atomic/lin_tests_dsl.ml
+++ b/src/atomic/lin_tests_dsl.ml
@@ -15,7 +15,8 @@ end
 
 module Lin_atomic = Lin_api.Make (Atomic_spec)
 
+let () = Util.set_ci_printing ()
 let () =
   QCheck_runner.run_tests_main
-    [ Lin_atomic.lin_test      ~count:100  ~name:"Atomic"      `Domain;
+    [ Lin_atomic.lin_test ~count:1000 ~name:"Atomic" `Domain;
     ]

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -53,3 +53,12 @@
  (modules lin_tests_dsl)
  ;(package multicoretests)
  (libraries multicorecheck.lin))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps lin_tests_dsl.exe)
+ (action
+  (progn
+   (bash "(./lin_tests_dsl.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-dsl-output.txt")
+   (run %{bin:check_error_count} "hashtbl/lin_tests_dsl" 1 lin-dsl-output.txt))))

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -38,14 +38,14 @@
  (libraries qcheck lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests.exe)
- (action
-  (progn
-   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
-   (run %{bin:check_error_count} "hashtbl/lin_tests" 1 lin-output.txt))))
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests.exe)
+;  (action
+;   (progn
+;    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+;    (run %{bin:check_error_count} "hashtbl/lin_tests" 1 lin-output.txt))))
 
 
 (executable

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -4,7 +4,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe))
+ (deps lin_tests.exe lin_tests_dsl.exe))
 
 (env
  (_
@@ -28,3 +28,17 @@
 ;   (progn
 ;    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
 ;    (run %{bin:check_error_count} "kcas/lin_tests" 1 lin-output.txt))))
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ (libraries multicorecheck.lin kcas)
+ ;(ocamlc_flags -dsource) ;; <- add this
+ ;(preprocess (pps ppx_deriving.show ppx_deriving.eq))
+ )
+
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests_dsl.exe)
+;  (action (run ./%{deps} --no-colors --verbose)))

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -33,9 +33,7 @@
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
  (libraries multicorecheck.lin kcas)
- ;(ocamlc_flags -dsource) ;; <- add this
- ;(preprocess (pps ppx_deriving.show ppx_deriving.eq))
- )
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule
 ;  (alias runtest)

--- a/src/kcas/lin_tests_dsl.ml
+++ b/src/kcas/lin_tests_dsl.ml
@@ -1,0 +1,97 @@
+
+(* ********************************************************************** *)
+(*                             Tests of [Kcas]                            *)
+(* ********************************************************************** *)
+module Common =
+struct
+  type 'a cas_result
+    = 'a Kcas.cas_result =
+    | Aborted
+    | Failed
+    | Success of 'a (*[@deriving show { with_path = false }, eq]*)
+
+  let show_cas_result show_a cr = match cr with
+    | Aborted -> "Aborted"
+    | Failed  -> "Failed"
+    | Success a -> Printf.sprintf "Success %s" (show_a a)
+
+  let eq_cas_result eq_a v1 v2 = match v1,v2 with
+    | Aborted,Aborted
+    | Failed,Failed -> true
+    | Success a, Success a' -> eq_a a a'
+    | _,_ -> false
+
+  let cas_result ty =
+    Lin_api.deconstructible (show_cas_result (Lin_api.print ty)) (eq_cas_result (Lin_api.equal ty))
+
+  let fun_none _ty =
+    let print_fun _ = "(fun _ -> None)" in
+    let fun_gen = QCheck.(make ~print:print_fun (Gen.return (fun _ -> None))) in
+    Lin_api.gen fun_gen print_fun
+
+  let fun_some _ty =
+    let print_fun _ = "(fun i -> Some i)" in
+    let fun_gen = QCheck.(make ~print:print_fun (Gen.return (fun i -> Some i))) in
+    Lin_api.gen fun_gen print_fun
+end
+
+module KConf =
+struct
+  type t = int Kcas.ref
+  let init () = Kcas.ref 0
+  let cleanup _ = ()
+
+  open Lin_api
+  let int = nat_small
+  let fun_none,fun_some,cas_result = Common.(fun_none,fun_some,cas_result)
+  let api =
+    [ val_ "Kcas.get"     Kcas.get     (t @-> returning int);
+      val_ "Kcas.set"     Kcas.set     (t @-> int @-> returning unit);
+      val_ "Kcas.cas"     Kcas.cas     (t @-> int @-> int @-> returning bool);
+      val_ "Kcas.try_map" Kcas.try_map (t @-> fun_none int @-> returning (cas_result int));
+      val_ "Kcas.try_map" Kcas.try_map (t @-> fun_some int @-> returning (cas_result int)); (* Seq,exec cannot fail - hence not linearizable with [try_map] *)
+      val_ "Kcas.map"     Kcas.map     (t @-> fun_none int @-> returning (cas_result int));
+      val_ "Kcas.map"     Kcas.map     (t @-> fun_some int @-> returning (cas_result int));
+      val_ "Kcas.incr"    Kcas.incr    (t @-> returning unit);
+      val_ "Kcas.decr"    Kcas.decr    (t @-> returning unit);
+    ]
+end
+
+module KT = Lin_api.Make(KConf)
+
+
+(* ********************************************************************** *)
+(*                           Tests of [Kcas.W1]                           *)
+(* ********************************************************************** *)
+module KW1Conf =
+struct
+  type t = int Kcas.W1.ref
+  let init () = Kcas.W1.ref 0
+  let cleanup _ = ()
+
+  open Lin_api
+  let int = nat_small
+  let fun_none,fun_some,cas_result = Common.(fun_none,fun_some,cas_result)
+  let api =
+    [ val_ "Kcas.W1.get"     Kcas.W1.get     (t @-> returning int);
+      val_ "Kcas.W1.set"     Kcas.W1.set     (t @-> int @-> returning unit);
+      val_ "Kcas.W1.cas"     Kcas.W1.cas     (t @-> int @-> int @-> returning bool);
+      val_ "Kcas.W1.try_map" Kcas.W1.try_map (t @-> fun_none int @-> returning (cas_result int));
+      (*val_ "Kcas.W1.try_map" Kcas.W1.try_map (t @-> fun_some int @-> returning (cas_result int));*) (* Seq,exec cannot fail - hence not linearizable with [try_map] *)
+      val_ "Kcas.W1.map"     Kcas.W1.map     (t @-> fun_none int @-> returning (cas_result int));
+      val_ "Kcas.W1.map"     Kcas.W1.map     (t @-> fun_some int @-> returning (cas_result int));
+      val_ "Kcas.W1.incr"    Kcas.W1.incr    (t @-> returning unit);
+      val_ "Kcas.W1.decr"    Kcas.W1.decr    (t @-> returning unit);
+    ]
+end
+
+(* module KW1T = Lin.Make(KW1Conf) *)
+module KW1T = Lin_api.Make(KW1Conf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+  (* Kcas tests *)
+  KT.lin_test     `Domain ~count:1000 ~name:"Kcas test";
+  KW1T.lin_test   `Domain ~count:1000 ~name:"Kcas.W1 test";
+]

--- a/src/kcas/lin_tests_dsl.ml
+++ b/src/kcas/lin_tests_dsl.ml
@@ -1,4 +1,3 @@
-
 (* ********************************************************************** *)
 (*                             Tests of [Kcas]                            *)
 (* ********************************************************************** *)
@@ -8,21 +7,10 @@ struct
     = 'a Kcas.cas_result =
     | Aborted
     | Failed
-    | Success of 'a (*[@deriving show { with_path = false }, eq]*)
-
-  let show_cas_result show_a cr = match cr with
-    | Aborted -> "Aborted"
-    | Failed  -> "Failed"
-    | Success a -> Printf.sprintf "Success %s" (show_a a)
-
-  let eq_cas_result eq_a v1 v2 = match v1,v2 with
-    | Aborted,Aborted
-    | Failed,Failed -> true
-    | Success a, Success a' -> eq_a a a'
-    | _,_ -> false
+    | Success of 'a [@@deriving show { with_path = false }, eq]
 
   let cas_result ty =
-    Lin_api.deconstructible (show_cas_result (Lin_api.print ty)) (eq_cas_result (Lin_api.equal ty))
+    Lin_api.deconstructible (show_cas_result (fun fmt a -> Format.pp_print_string fmt (Lin_api.print ty a))) (equal_cas_result (Lin_api.equal ty))
 
   let fun_none _ty =
     let print_fun _ = "(fun _ -> None)" in
@@ -85,13 +73,11 @@ struct
     ]
 end
 
-(* module KW1T = Lin.Make(KW1Conf) *)
 module KW1T = Lin_api.Make(KW1Conf)
 ;;
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  (* Kcas tests *)
   KT.lin_test     `Domain ~count:1000 ~name:"Kcas test";
   KW1T.lin_test   `Domain ~count:1000 ~name:"Kcas.W1 test";
 ]

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -33,17 +33,26 @@
  (libraries qcheck lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests.exe)
- (action
-  (progn
-   (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
-   (run %{bin:check_error_count} "lazy/lin_tests" 2 lin-output.txt))))
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests.exe)
+;  (action
+;   (progn
+;    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
+;    (run %{bin:check_error_count} "lazy/lin_tests" 2 lin-output.txt))))
 
 (executable
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
  ;(package multicoretests)
  (libraries multicorecheck.lin))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps lin_tests_dsl.exe)
+ (action
+  (progn
+   (bash "(./lin_tests_dsl.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-dsl-output.txt")
+   (run %{bin:check_error_count} "lazy/lin_tests_dsl" 2 lin-dsl-output.txt))))

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -4,7 +4,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe stm_tests.exe))
+ (deps lin_tests.exe stm_tests.exe lin_tests_dsl.exe))
 
 (env
  (_
@@ -41,3 +41,9 @@
   (progn
    (bash "(./lin_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-output.txt")
    (run %{bin:check_error_count} "lazy/lin_tests" 2 lin-output.txt))))
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ ;(package multicoretests)
+ (libraries multicorecheck.lin))

--- a/src/lazy/lin_tests_dsl.ml
+++ b/src/lazy/lin_tests_dsl.ml
@@ -1,0 +1,75 @@
+(** parallel linearization tests of Lazy *)
+
+(* a simple work item, from ocaml/testsuite/tests/misc/takc.ml *)
+let rec tak x y z =
+  if x > y then tak (tak (x-1) y z) (tak (y-1) z x) (tak (z-1) x y)
+           else z
+
+let work () =
+  let r = ref 0 in
+  for _ = 1 to 100 do
+    r := !r + tak 18 12 6;
+    (*assert (7 = tak 18 12 6);*)
+  done;
+  !r
+
+(*
+module Lazy :
+  sig
+    type 'a t = 'a CamlinternalLazy.t
+    exception Undefined
+    external force : 'a t -> 'a = "%lazy_force"
+    val map : ('a -> 'b) -> 'a t -> 'b t
+    val is_val : 'a t -> bool
+    val from_val : 'a -> 'a t
+    val map_val : ('a -> 'b) -> 'a t -> 'b t
+    val from_fun : (unit -> 'a) -> 'a t
+    val force_val : 'a t -> 'a
+  end
+*)
+
+module LBase =
+struct
+  type t = int Lazy.t
+  let cleanup _ = ()
+
+  open Lin_api
+
+  (* hack to work around missing function generators *)
+  let fun_gen _ty _ty' =
+    let print_fun _ = "Stdlib.succ" in
+    let fun_gen = QCheck.(make ~print:print_fun (Gen.return Stdlib.succ)) in
+    Lin_api.gen fun_gen print_fun
+
+  let force_map f l = Lazy.force (Lazy.map f l)
+  let force_map_val f l = Lazy.force (Lazy.map_val f l)
+  let int = nat_small
+
+  let api =
+    [ val_ "Lazy.force"                Lazy.force     (t @-> returning_or_exc int);
+      val_ "Lazy.force_val"            Lazy.force_val (t @-> returning_or_exc int);
+      val_ "Lazy.is_val"               Lazy.is_val    (t @-> returning bool);
+    (*val_ "Lazy.map"                  Lazy.map       (fun_gen int int @-> t @-> returning_or_exc t);*)
+      val_ "Lazy.force o Lazy.map"     force_map      (fun_gen int int @-> t @-> returning_or_exc int);
+    (*val_ "Lazy.map_val"              Lazy.map       (fun_gen int int @-> t @-> returning_or_exc t);*)
+      val_ "Lazy.force o Lazy.map_val" force_map_val  (fun_gen int int @-> t @-> returning_or_exc int);
+    ]
+end
+
+module LTlazyAPI = struct include LBase let init () = lazy (work ()) end
+module LTlazy    = Lin_api.Make(LTlazyAPI)
+
+module LTfromvalAPI = struct include LBase let init () = Lazy.from_val 42 end
+module LTfromval = Lin_api.Make(LTfromvalAPI)
+
+module LTfromfunAPI = struct include LBase let init () = Lazy.from_fun work end
+module LTfromfun = Lin_api.Make(LTfromfunAPI)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main
+  (let count = 100 in
+   [LTlazy.lin_test       `Domain ~count ~name:"lazy test";
+    LTfromval.lin_test    `Domain ~count ~name:"lazy test from_val";
+    LTfromfun.lin_test    `Domain ~count ~name:"lazy test from_fun";
+   ])

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,0 @@
-(test
-  (name lin_api)
-  (package multicorecheck)
-  (libraries multicorecheck.lin))


### PR DESCRIPTION
This is a ~work-in-progress~ PR to fix #54.
- For `Atomic` we simply rename the existing example
- Porting `Kcas` required extending the interface of `Lin_api` to allow users to write custom types in signatures
- There's also a port of `Lazy` with a workaround for the lack of function generators

~Missing ports:~
- ~src/neg_tests/*~
- ~src/queue~
- ~src/stack~

*(edit: missing ports in #94)*