### PR TITLE
Reorganize and rename Lin_api combinators

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -24,17 +24,17 @@ let print_string s = Printf.sprintf "%S" s
 
 let unit =           GenDeconstr (QCheck.unit,           QCheck.Print.unit, (=))
 let bool =           GenDeconstr (QCheck.bool,           QCheck.Print.bool, (=))
+let char =           GenDeconstr (qcheck_char,           print_char,        (=))
+let char_printable = GenDeconstr (qcheck_printable_char, print_char,        (=))
 let nat_small =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
 let int =            GenDeconstr (QCheck.int,            QCheck.Print.int,  (=))
 let int_small =      GenDeconstr (QCheck.small_int,      QCheck.Print.int,  (=))
-let char =           GenDeconstr (qcheck_char,           print_char,        (=))
-let char_printable = GenDeconstr (qcheck_printable_char, print_char,        (=))
-let string =         GenDeconstr (QCheck.string,         print_string,      String.equal)
-let pos_int =        GenDeconstr (QCheck.pos_int,        QCheck.Print.int,  (=))
-let small_nat =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
+let int_pos =        GenDeconstr (QCheck.pos_int,        QCheck.Print.int,  (=))
+let int_bound b =    GenDeconstr (QCheck.int_bound b,    QCheck.Print.int,  (=))
 let int32 =          GenDeconstr (QCheck.int32,          Int32.to_string,   Int32.equal)
 let int64 =          GenDeconstr (QCheck.int64,          Int64.to_string,   Int64.equal)
 let float =          GenDeconstr (QCheck.float,          Float.to_string,   Float.equal)
+let string =         GenDeconstr (QCheck.string,         print_string,      String.equal)
 
 let option : type a c s. ?ratio:float -> (a, c, s, combinable) ty -> (a option, c, s, combinable) ty =
   fun ?ratio ty ->
@@ -50,13 +50,8 @@ let list : type a c s. (a, c, s, combinable) ty -> (a list, c, s, combinable) ty
   | GenDeconstr (arb, print, eq) -> GenDeconstr (QCheck.list arb, QCheck.Print.list print, List.equal eq)
   | Deconstr (print, eq) -> Deconstr (QCheck.Print.list print, List.equal eq)
 
-
 let state = State
 let t = state
-
-let int_bound bound =
-  let arb = QCheck.int_bound bound in
-  GenDeconstr (arb, QCheck.Print.int, (=))
 
 let print_result print_ok print_err = function
   | Ok x    -> Printf.sprintf "Ok (%s)" (print_ok x)

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -9,17 +9,18 @@ type (_, _, _, _) ty
 
 val unit : (unit, 'a, 'b, combinable) ty
 val bool : (bool, 'a, 'b, combinable) ty
+val char : (char, 'a, 'b, combinable) ty
+val char_printable : (char, 'a, 'b, combinable) ty
 val nat_small : (int, 'a, 'b, combinable) ty
 val int : (int, 'a, 'b, combinable) ty
 val int_small : (int, 'a, 'b, combinable) ty
-val char : (char, 'a, 'b, combinable) ty
-val char_printable : (char, 'a, 'b, combinable) ty
-val string : (String.t, 'a, 'b, combinable) ty
-val pos_int : (int, 'a, 'b, combinable) ty
-val small_nat : (int, 'a, 'b, combinable) ty
+val int_pos : (int, 'a, 'b, combinable) ty
+val int_bound : int -> (int, 'a, 'b, combinable) ty
 val int32 : (Int32.t, 'a, 'b, combinable) ty
 val int64 : (Int64.t, 'a, 'b, combinable) ty
 val float : (float, 'a, 'b, combinable) ty
+val string : (String.t, 'a, 'b, combinable) ty
+
 val option :
   ?ratio:float ->
   ('a, 'c, 's, combinable) ty -> ('a option, 'c, 's, combinable) ty
@@ -29,7 +30,6 @@ val opt :
 val list : ('a, 'c, 's, combinable) ty -> ('a list, 'c, 's, combinable) ty
 val state : ('a, constructible, 'a, noncombinable) ty
 val t : ('a, constructible, 'a, noncombinable) ty
-val int_bound : int -> (int, 'a, 'b, combinable) ty
 val print_result :
   ('a -> string) -> ('b -> string) -> ('a, 'b) result -> string
 val or_exn :

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -19,12 +19,11 @@ module EConf =
                  end)
 
     type t = string E.t
-   
     let init () = E.create 42
     let cleanup _ = ()
 
     open Lin_api
-    let int = small_nat
+    let int = nat_small
     let api =
       [ val_ "Ephemeron.clear"    E.clear    (t @-> returning unit);
         val_ "Ephemeron.add"      E.add      (t @-> int @-> string @-> returning unit);


### PR DESCRIPTION
This little PR reorganizes and renames some of the `Lin_api` combinators:
- we had both `nat_small` and `small_nat` too many lines apart to notice, so remove the latter and order them thematically (`int*` together and so forth, largely moving from smaller to larger base types)
- rename `pos_int` to `int_pos`
- finally update the `Ephemeron` test to reflect the renaming