### PR TITLE
Clean-up dependencies to qcheck>=0.19

### DIFF
--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -10,14 +10,8 @@ dev-repo:     "git+https://github.com/jmid/multicoretests.git"
 depends: [
   "base-domains"
   "dune"                {>= "2.9.3"}
-  "qcheck-core"         {>= "0.18.1"}
-  "qcheck"              {>= "0.18.1"}
+  "qcheck"              {>= "0.19"}
   "odoc"                {with-doc}
-]
-pin-depends: [
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
 ]
 
 build: [

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -12,8 +12,7 @@ depends: [
   "domainslib"          {>= "0.4.2"}
   "ppx_deriving"        {>= "5.2.1"}
   "ounit2"              {>= "2.2.6"}
-  "qcheck-core"         {>= "0.18.1"}
-  "qcheck"              {>= "0.18.1"}
+  "qcheck"              {>= "0.19"}
   "ppx_deriving_qcheck" {>= "0.2.0"}
   "kcas"                {>= "0.14"}
   "lockfree"            {>= "0.13"}
@@ -21,11 +20,6 @@ depends: [
   "multicorecheck"      {= version}
 ]
 pin-depends: [
-  ["qcheck-core.0.18.1"        "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck-ounit.0.18.1"       "git+https://github.com/c-cube/qcheck.git#master"]
-  ["qcheck.0.18.1"             "git+https://github.com/c-cube/qcheck.git#master"]
-  ["ppx_deriving_qcheck.0.2.0" "git+https://github.com/c-cube/qcheck.git#master"]
-
   ["domainslib.0.4.2"          "git+https://github.com/ocaml-multicore/domainslib#master"]
   ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
   ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]


### PR DESCRIPTION
This PR cleans up the dependencies to the newly released QCheck 0.19, thus reducing the pinned dependencies significantly.