### PR TITLE
Add Lin_api test of Bytes

### DIFF
--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -1,0 +1,29 @@
+;; Tests of the stdlib Bytes library
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps lin_tests_dsl.exe))
+
+(env
+ (_
+  (binaries
+   (../check_error_count.exe as check_error_count))))
+
+
+;; Linearizability tests utilizing ppx_deriving_qcheck
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ (libraries multicorecheck.lin))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps lin_tests_dsl.exe)
+ (action
+  (progn
+   (bash "(./lin_tests_dsl.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-dsl-output.txt")
+   (run %{bin:check_error_count} "bytes/lin_tests_dsl" 0 lin-dsl-output.txt))))

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -6,13 +6,7 @@
  (package multicoretests)
  (deps lin_tests_dsl.exe))
 
-(env
- (_
-  (binaries
-   (../check_error_count.exe as check_error_count))))
-
-
-;; Linearizability tests utilizing ppx_deriving_qcheck
+;; Linearizability tests
 
 (executable
  (name lin_tests_dsl)
@@ -23,7 +17,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action
-  (progn
-   (bash "(./lin_tests_dsl.exe --no-colors --verbose || echo 'test run triggered an error') | tee lin-dsl-output.txt")
-   (run %{bin:check_error_count} "bytes/lin_tests_dsl" 0 lin-dsl-output.txt))))
+ (action (run ./%{deps} --no-colors --verbose)))

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -1,0 +1,26 @@
+(* ********************************************************************** *)
+(*                      Tests of thread-unsafe [Bytes]                    *)
+(* ********************************************************************** *)
+module BConf = struct
+  type t = Bytes.t
+  let init () = Stdlib.Bytes.make 42 '0'
+  let cleanup _ = ()
+
+  open Lin_api
+  let api = [
+    val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
+    val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
+    val_ "Bytes.length"      Bytes.length      (t @-> returning int);
+    val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
+    val_ "Bytes.index_from"  Bytes.index_from  (t @-> int @-> char @-> returning_or_exc int)]
+end
+
+module BT = Lin_api.Make(BConf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+  BT.lin_test `Domain ~count:1000 ~name:"Bytes test";
+  BT.lin_test `Thread ~count:1000 ~name:"Bytes test";
+]

--- a/src/dune
+++ b/src/dune
@@ -6,6 +6,7 @@
        ;; stdlib, in alphabetic order
        (alias atomic/default)
        (alias buffer/default)
+       (alias bytes/default)
        (alias domain/default)
        (alias ephemeron/default)
        (alias hashtbl/default)


### PR DESCRIPTION
This PR contains Lin_api tests of the `Bytes` module from @naomiiiiiiiii

These are the tests that originally triggered an infinite loop on ARM64.

(The commits should probably be squashed before merging)