### PR TITLE
Restore CI

### DIFF
--- a/src/domainslib/task_more_deps.ml
+++ b/src/domainslib/task_more_deps.ml
@@ -97,7 +97,7 @@ let test_one_pool ~domain_bound ~promise_bound =
      Util.repeat 10
     (fun test_input ->
       (*Printf.printf "%s\n%!" (show_test_input test_input);*)
-      let pool = Task.setup_pool ~num_additional_domains:test_input.num_domains () in
+      let pool = Task.setup_pool ~num_domains:test_input.num_domains () in
       Task.run pool (fun () ->
           let ps = build_dep_graph pool test_input in
           List.iter (fun p -> Task.await pool p) ps);

--- a/src/domainslib/task_one_dep.ml
+++ b/src/domainslib/task_one_dep.ml
@@ -123,7 +123,7 @@ let test_one_pool ~domain_bound ~promise_bound =
       (*Util.prop_timeout 10 @@*)
       fun input ->
       (*Printf.printf "%s\n%!" (show_test_input test_input);*)
-      let pool = Task.setup_pool ~num_additional_domains:input.num_domains () in
+      let pool = Task.setup_pool ~num_domains:input.num_domains () in
       Task.run pool (fun () ->
           let ps = build_dep_graph pool input in
           List.iter (fun p -> Task.await pool p) ps);
@@ -139,8 +139,8 @@ let test_two_pools_sync_last ~domain_bound ~promise_bound =
      (*Util.prop_timeout 10 @@*)
       fun (input1,input2) ->
         (*Printf.printf "%s\n%!" (Print.pair show_test_input show_test_input (input1,input2));*)
-        let pool1 = Task.setup_pool ~num_additional_domains:input1.num_domains () in
-        let pool2 = Task.setup_pool ~num_additional_domains:input2.num_domains () in
+        let pool1 = Task.setup_pool ~num_domains:input1.num_domains () in
+        let pool2 = Task.setup_pool ~num_domains:input2.num_domains () in
         let ps1 = build_dep_graph pool1 input1 in
         let ps2 = build_dep_graph pool2 input2 in
         Task.run pool1 (fun () -> List.iter (fun p -> Task.await pool1 p) ps1);
@@ -158,8 +158,8 @@ let test_two_nested_pools ~domain_bound ~promise_bound =
      (*Util.prop_timeout 10 @@*)
       fun (input1,input2) ->
         (*Printf.printf "%s\n%!" (Print.pair show_test_input show_test_input (input1,input2));*)
-        let pool1 = Task.setup_pool ~num_additional_domains:input1.num_domains () in
-        let pool2 = Task.setup_pool ~num_additional_domains:input2.num_domains () in
+        let pool1 = Task.setup_pool ~num_domains:input1.num_domains () in
+        let pool2 = Task.setup_pool ~num_domains:input2.num_domains () in
         Task.run pool1 (fun () ->
             Task.run pool2 (fun () ->
                 let ps1 = build_dep_graph pool1 input1 in

--- a/src/domainslib/task_parallel.ml
+++ b/src/domainslib/task_parallel.ml
@@ -11,7 +11,7 @@ let print_array a =
   Buffer.contents b
 
 let scan_task num_doms array_size =
-  let pool = Task.setup_pool ~num_additional_domains:num_doms () in
+  let pool = Task.setup_pool ~num_domains:num_doms () in
   let a = Task.run pool (fun () -> Task.parallel_scan pool (+) (Array.make array_size 1)) in
   Task.teardown_pool pool;
   a
@@ -19,9 +19,9 @@ let scan_task num_doms array_size =
 let test_parallel_for =
   Test.make ~name:"test Task.parallel_for" ~count:1000
     (triple (int_bound 10) small_nat small_nat)
-    (fun (num_additional_domains,array_size,chunk_size) ->
-       (*Printf.printf "(%i,%i)\n%!" num_additional_domains array_size;*)
-       let pool = Task.setup_pool ~num_additional_domains () in
+    (fun (num_domains,array_size,chunk_size) ->
+       (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)
+       let pool = Task.setup_pool ~num_domains () in
        let res = Task.run pool (fun () ->
            let a = Atomic.make 0 in
            Task.parallel_for ~chunk_size ~start:0 ~finish:(array_size-1) ~body:(fun _ -> Atomic.incr a) pool;
@@ -32,9 +32,9 @@ let test_parallel_for =
 let test_parallel_for_reduce =
   Test.make ~name:"test Task.parallel_for_reduce" ~count:1000
     (triple (int_bound 10) small_nat small_nat)
-    (fun (num_additional_domains,array_size,chunk_size) ->
-       (*Printf.printf "(%i,%i,%i)\n%!" num_additional_domains array_size chunk_size;*)
-       let pool = Task.setup_pool ~num_additional_domains () in
+    (fun (num_domains,array_size,chunk_size) ->
+       (*Printf.printf "(%i,%i,%i)\n%!" num_domains array_size chunk_size;*)
+       let pool = Task.setup_pool ~num_domains () in
        let res = Task.run pool (fun () ->
            Task.parallel_for_reduce ~chunk_size ~start:0 ~finish:(array_size-1) ~body:(fun _ -> 1) pool (+) 0) in
        Task.teardown_pool pool;
@@ -43,9 +43,9 @@ let test_parallel_for_reduce =
 let test_parallel_scan =
   Test.make ~name:"test Task.parallel_scan" ~count:1000
     (pair (int_bound 10) small_nat)
-    (fun (num_additional_domains,array_size) ->
-       (*Printf.printf "(%i,%i)\n%!" num_additional_domains array_size;*)
-       let pool = Task.setup_pool ~num_additional_domains () in
+    (fun (num_domains,array_size) ->
+       (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)
+       let pool = Task.setup_pool ~num_domains () in
        let a = Task.run pool (fun () -> Task.parallel_scan pool (+) (Array.make array_size 1)) in
        Task.teardown_pool pool;
        a = Array.init array_size (fun i -> i + 1))


### PR DESCRIPTION
CI is failing since in `Domainslib`, `num_additional_domains` was renamed to `num_domains`: https://github.com/ocaml-multicore/domainslib/pull/78
This PR updates the tests to use `num_domains` accordingly.
With it, the CI should hopefully go green again... 🤞