### PR TITLE
Add infinite loop issue triggered by Bytes tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,13 @@ In `STM` a functor `STM.AddGC` is also available. It inserts calls to
 Issues
 ======
 
+Infinite loop in `caml_scan_stack` on ARM64
+-------------------------------------------
+
+The tests triggered [an apparent infinite loop on ARM64 while amd64 would complete the tests as expected]
+(https://github.com/ocaml/ocaml/issues/11425).
+
+
 Unsafe `Buffer` module
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We are still experimenting with the interfaces, so consider yourself warned.
 Installation instructions, and running the tests
 ================================================
 
-Both the libraries and the test suite requires OCaml 5.0:
+Both the libraries and the test suite require OCaml 5.0:
 ```
 opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
 opam update

--- a/README.md
+++ b/README.md
@@ -320,8 +320,7 @@ Issues
 Infinite loop in `caml_scan_stack` on ARM64
 -------------------------------------------
 
-The tests triggered [an apparent infinite loop on ARM64 while amd64 would complete the tests as expected]
-(https://github.com/ocaml/ocaml/issues/11425).
+The tests triggered [an apparent infinite loop on ARM64 while amd64 would complete the tests as expected](https://github.com/ocaml/ocaml/issues/11425).
 
 
 Unsafe `Buffer` module


### PR DESCRIPTION
This PR
- adds the infinite loop issue triggered by `Bytes` tests
- turns a singular `requires` into plural `require`