### PR TITLE
Add array tests

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -20,6 +20,8 @@ type _ ty +=
   | Option : 'a ty -> 'a option ty
   | Result : 'a ty * 'b ty -> ('a, 'b) result ty
   | List : 'a ty -> 'a list ty
+  | Array : 'a ty -> 'a array ty
+  | Seq : 'a ty -> 'a Seq.t ty
 
 type 'a ty_show = 'a ty * ('a -> string)
 
@@ -48,6 +50,12 @@ let result spec_ok spec_err =
 let list spec =
   let (ty,show) = spec in
   (List ty, QCheck.Print.list show)
+let array spec =
+  let (ty,show) = spec in
+  (Array ty, QCheck.Print.array show)
+let seq spec =
+  let (ty,show) = spec in
+  (Seq ty, fun s -> QCheck.Print.list show (List.of_seq s))
 
 type res =
   Res : 'a ty_show * 'a -> res

--- a/src/array/dune
+++ b/src/array/dune
@@ -1,0 +1,20 @@
+;; Test of the array library
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps stm_tests.exe))
+
+
+(executable
+ (name stm_tests)
+ (modules stm_tests)
+ (libraries qcheck STM)
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps stm_tests.exe)
+ (action (run ./%{deps} --no-colors --verbose)))

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -1,0 +1,116 @@
+open QCheck
+open STM
+open Util
+
+(** parallel STM tests of Array *)
+
+module AConf =
+struct
+  type cmd =
+    | Length
+    | Get of int
+    | Set of int * char
+    | Sub of int * int
+    | Copy
+    | Fill of int * int * char
+    | To_list
+    | Mem of char
+    | Sort
+    | To_seq
+  [@@deriving show { with_path = false }]
+
+  type state = char list
+  type sut = char Array.t
+
+  let arb_cmd s =
+    let int_gen = Gen.(oneof [small_nat; int_bound (List.length s - 1)]) in
+    let char_gen = Gen.printable in
+    QCheck.make ~print:show_cmd (*~shrink:shrink_cmd*)
+      Gen.(oneof
+             [ return Length;
+               map (fun i -> Get i) int_gen;
+               map2 (fun i c -> Set (i,c)) int_gen char_gen;
+               map2 (fun i len -> Sub (i,len)) int_gen int_gen; (* hack: reusing int_gen for length *)
+               return Copy;
+               map3 (fun i len c -> Fill (i,len,c)) int_gen int_gen char_gen; (* hack: reusing int_gen for length *)
+               return To_list;
+               map (fun c -> Mem c) char_gen;
+               return Sort;
+               return To_seq;
+             ])
+
+  let array_size = 16
+
+  let init_state  = List.init array_size (fun _ -> 'a')
+
+  let next_state c s = match c with
+    | Length -> s
+    | Get _  -> s
+    | Set (i,c) ->
+      List.mapi (fun j c' -> if i=j then c else c') s
+    | Sub (_,_) -> s
+    | Copy -> s
+    | Fill (i,l,c) ->
+      if i >= 0 && l >= 0 && i+l-1 < List.length s
+      then
+        List.mapi (fun j c' -> if i <= j && j <= i+l-1 then c else c') s
+      else s
+    | To_list -> s
+    | Mem _ -> s
+    | Sort -> List.sort Char.compare s
+    | To_seq -> s
+
+  let init_sut () = Array.make array_size 'a'
+  let cleanup _   = ()
+
+  let precond c _s = match c with
+    | _ -> true
+
+  let run c a = match c with
+    | Length       -> Res (int, Array.length a)
+    | Get i        -> Res (result char exn, protect (Array.get a) i)
+    | Set (i,c)    -> Res (result unit exn, protect (Array.set a i) c)
+    | Sub (i,l)    -> Res (result (array char) exn, protect (Array.sub a i) l)
+    | Copy         -> Res (array char, Array.copy a)
+    | Fill (i,l,c) -> Res (result unit exn, protect (Array.fill a i l) c)
+    | To_list      -> Res (list char, Array.to_list a)
+    | Mem c        -> Res (bool, Array.mem c a)
+    | Sort         -> Res (unit, Array.sort Char.compare a)
+    | To_seq       -> Res (seq char, List.to_seq (List.of_seq (Array.to_seq a))) (* workaround: Array.to_seq is lazy and will otherwise see and report later Array.set state changes... *)
+
+  let postcond c (s:char list) res = match c, res with
+    | Length, Res ((Int,_),i) -> i = List.length s
+    | Get i, Res ((Result (Char,Exn),_), r) ->
+      if i < 0 || i >= List.length s
+      then r = Error (Invalid_argument "index out of bounds")
+      else r = Ok (List.nth s i)
+    | Set (i,_), Res ((Result (Unit,Exn),_), r) ->
+      if i < 0 || i >= List.length s
+      then r = Error (Invalid_argument "index out of bounds")
+      else r = Ok ()
+    | Sub (i,l), Res ((Result (Array Char,Exn),_), r) ->
+      if i < 0 || l < 0 || i+l > List.length s
+      then r = Error (Invalid_argument "Array.sub")
+      else r = Ok (Array.of_list (List.filteri (fun j _ -> i <= j && j <= i+l-1) s))
+    | Copy, Res ((Array Char,_),r) -> Array.to_list r = s
+    | Fill (i,l,_), Res ((Result (Unit,Exn),_), r) ->
+      if i < 0 || l < 0 || i+l > List.length s
+      then r = Error (Invalid_argument "Array.fill")
+      else r = Ok ()
+    | To_list, Res ((List Char,_),cs) -> cs = s
+    | Mem c, Res ((Bool,_),r) -> r = List.mem c s
+    | Sort, Res ((Unit,_),r) -> r = ()
+    | To_seq, Res ((Seq Char,_),r) -> Seq.equal (=) r (List.to_seq s)
+    | _, _ -> false
+end
+
+module ArraySTM = STM.Make(AConf)
+
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main
+  (let count = 1000 in
+   [ArraySTM.agree_test         ~count ~name:"array test";
+    ArraySTM.neg_agree_test_par ~count ~name:"array test parallel" (* this test is expected to fail *)
+])

--- a/src/dune
+++ b/src/dune
@@ -4,6 +4,7 @@
  (package multicoretests)
  (deps (alias neg_tests/default)
        ;; stdlib, in alphabetic order
+       (alias array/default)
        (alias atomic/default)
        (alias buffer/default)
        (alias bytes/default)


### PR DESCRIPTION
This PR adds `STM` tests of (parts of) the `Stdlib.Array` module.
To do so, it adds missing combinators for `Seq.t` and `array` to `STM`.

With it one is able to observe, e.g., partial writes:
```
--- Info -----------------------------------------------------------------------

Negative test parallel array test parallel failed as expected (27 shrink steps):

                             |           
                             |           
                  .---------------------.
                  |                     |           
          (Fill (4, 5, 'V'))          To_seq        


+++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Messages for test parallel array test parallel:

  Results incompatible with linearized model

                                                                                               |                                            
                                                                                               |                                            
                                                 .------------------------------------------------------------------------------------------.
                                                 |                                                                                          |                                            
                                   (Fill (4, 5, 'V')) : Ok (())                                 To_seq : ['a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'V'; 'V'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a']

```