### PR TITLE
Add Lin array tests

### DIFF
--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -33,6 +33,9 @@ val opt :
   ?ratio:float ->
   ('a, 'b, 'c, combinable) ty -> ('a option, 'b, 'c, combinable) ty
 val list : ('a, 'c, 's, combinable) ty -> ('a list, 'c, 's, combinable) ty
+val array : ('a, 'c, 's, combinable) ty -> ('a array, 'c, 's, combinable) ty
+val seq : ('a, 'c, 's, combinable) ty -> ('a Seq.t, 'c, 's, combinable) ty
+
 val state : ('a, constructible, 'a, noncombinable) ty
 val t : ('a, constructible, 'a, noncombinable) ty
 val print_result :

--- a/src/README.md
+++ b/src/README.md
@@ -3,45 +3,60 @@ Current (experimental) PBTs of multicore
 
 Tests utilizing the parallel STM.ml capability:
 
+ - [array/stm_tests.ml](array/stm_tests.ml) contains sequential and
+   parallel tests of the `Array` module
+
  - [atomic/stm_tests.ml](atomic/stm_tests.ml) contains sequential and
-   parallel tests of the `Atomic` module using STM.ml
+   parallel tests of the `Atomic` module
 
  - [buffer/stm_tests.ml](buffer/stm_tests.ml) contains sequential and
-   parallel tests of the `Buffer` module using STM.ml
+   parallel tests of the `Buffer` module
 
  - [ephemeron/stm_tests.ml](ephemeron/stm_tests.ml) contains sequential and
-   parallel tests of the `Ephemeron` module using STM.ml
+   parallel tests of the `Ephemeron` module
+
+ - [hashtbl/stm_tests.ml](hashtbl/stm_tests.ml) contains sequential and
+   parallel tests of the `Hashtbl` module
 
  - [lazy/stm_tests.ml](lazy/stm_tests.ml) contains sequential and
-   parallel tests of the `Lazy` module using STM.ml
+   parallel tests of the `Lazy` module
 
  - [lockfree/ws_deque_test.ml](lockfree/ws_deque_test.ml) contains sequential
    and parallel tests of [ws_deque.ml](https://github.com/ocaml-multicore/lockfree/blob/main/src/ws_deque.ml)
-   from [Lockfree](https://github.com/ocaml-multicore/lockfree) using STM.ml
+   from [Lockfree](https://github.com/ocaml-multicore/lockfree)
 
  - [domainslib/chan_stm_tests.ml](domainslib/chan_stm_tests.ml) contains sequential and
    parallel tests of the `Chan` module from [Domainslib](https://github.com/ocaml-multicore/domainslib)
-   using STM.ml
+
 
 
 
 Tests utilizing the linearizability tests of Lin.ml:
 
- - [atomic/lin_tests.ml](atomic/lin_tests.ml) contains experimental `Lin`-tests of `Atomic`
+ - [array/lin_tests.ml](array/lin_tests.ml) and [array/lin_tests_dsl.ml](array/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Array`
+
+ - [atomic/lin_tests.ml](atomic/lin_tests.ml) and [atomic/lin_tests_dsl.ml](atomic/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Atomic`
+
+ - [bytes/lin_tests_dsl.ml](bytes/lin_tests_dsl.ml) contains experimental `Lin_api`-tests of `Bytes`
 
  - [ephemeron/lin_tests_dsl.ml](ephemeron/lin_tests_dsl.ml) contains experimental `Lin_api`-tests of `Ephemeron`
 
  - [hashtbl/lin_tests.ml](hashtbl/lin_tests.ml) and [hashtbl/lin_tests_dsl.ml](hashtbl/lin_tests_dsl.ml)
-   contains experimental `Lin` and `Lin_api`-tests of `Hashtbl`
+   contain experimental `Lin` and `Lin_api`-tests of `Hashtbl`
 
- - [queue/lin_tests.ml](queue/lin_tests.ml) contains experimental `Lin`-tests of `Queue`
+ - [lazy/lin_tests.ml](lazy/lin_tests.ml) and [lazy/lin_tests_dsl.ml](lazy/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Lazy`
 
- - [stack/lin_tests.ml](stack/lin_tests.ml) contains experimental `Lin`-tests of `Stack`
+ - [queue/lin_tests.ml](queue/lin_tests.ml) and [queue/lin_tests_dsl.ml](queue/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Queue`
 
- - [lazy/lin_tests.ml](lazy/lin_tests.ml) contains experimental `Lin`-tests of `Lazy`
+ - [stack/lin_tests.ml](stack/lin_tests.ml) and [stack/lin_tests_dsl.ml](stack/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Stack`
 
- - [kcas/lin_tests.ml](kcas/lin_tests.ml) contains experimental
-   `Lin`-tests of `Kcas` and `Kcas.W1` (Note: `Kcas` is subsumed by `Stdlib.Atomic`).
+ - [kcas/lin_tests.ml](kcas/lin_tests.ml) and [kcas/lin_tests_dsl.ml](kcas/lin_tests_dsl.ml)
+   contain experimental `Lin` and `Lin_api`-tests of `Kcas` and `Kcas.W1` (Note: `Kcas` is subsumed by `Stdlib.Atomic`).
 
 
 

--- a/src/array/dune
+++ b/src/array/dune
@@ -4,8 +4,10 @@
 (alias
  (name default)
  (package multicoretests)
- (deps stm_tests.exe))
-
+ (deps
+   stm_tests.exe
+   lin_tests.exe
+   lin_tests_dsl.exe))
 
 (executable
  (name stm_tests)
@@ -17,4 +19,29 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
+ (action (run ./%{deps} --no-colors --verbose)))
+
+(executable
+ (name lin_tests)
+ (modules lin_tests)
+ (flags (:standard -w -27))
+ (libraries qcheck lin)
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests.exe)
+;  (action (run ./%{deps} --no-colors --verbose)))
+
+(executable
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ ;(package multicoretests)
+ (libraries multicorecheck.lin))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps lin_tests_dsl.exe)
  (action (run ./%{deps} --no-colors --verbose)))

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -1,0 +1,65 @@
+open QCheck
+
+(** ********************************************************************** *)
+(**                      Tests of thread-unsafe [Array]                    *)
+(** ********************************************************************** *)
+module AConf =
+struct
+  type t = char array
+
+  type cmd =
+    | Length
+    | Get of int'
+    | Set of int' * char'
+    | Sub of int' * int'
+    | Copy
+    | Fill of int' * int' * char'
+    | To_list
+    | Mem of char'
+    | Sort
+    | To_seq [@@deriving qcheck, show { with_path = false }]
+  and int' = int [@gen Gen.small_nat]
+  and char' = char [@gen Gen.printable]
+
+  let shrink_cmd c = Iter.empty
+
+  open Util
+  (*let pp_exn = Util.pp_exn*)
+  type res =
+    | RLength of int
+    | RGet of ((char, exn) result)
+    | RSet of ((unit, exn) result)
+    | RSub of ((char array, exn) result)
+    | RCopy of char array
+    | RFill of ((unit, exn) result)
+    | RTo_list of char list
+    | RMem of bool
+    | RSort of unit
+    | RTo_seq of (char Seq.t [@printer fun fmt seq -> fprintf fmt "%s" (QCheck.Print.(list char) (List.of_seq seq))])
+  [@@deriving show { with_path = false }, eq]
+
+  let array_size = 16
+
+  let init () = Array.make array_size 'a'
+
+  let run c a = match c with
+    | Length        -> RLength (Array.length a)
+    | Get i         -> RGet (Util.protect (Array.get a) i)
+    | Set (i,c)     -> RSet (Util.protect (Array.set a i) c)
+    | Sub (i,l)     -> RSub (Util.protect (Array.sub a i) l)
+    | Copy          -> RCopy (Array.copy a)
+    | Fill (i,l,c)  -> RFill (Util.protect (Array.fill a i l) c)
+    | To_list       -> RTo_list (Array.to_list a)
+    | Mem c         -> RMem (Array.mem c a)
+    | Sort          -> RSort (Array.sort Char.compare a)
+    | To_seq        -> RTo_seq (List.to_seq (List.of_seq (Array.to_seq a))) (* workaround: Array.to_seq is lazy and will otherwise see and report later Array.set state changes... *)
+  let cleanup _ = ()
+end
+
+module AT = Lin.Make(AConf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+  AT.neg_lin_test `Domain ~count:1000 ~name:"Array test";
+]

--- a/src/array/lin_tests_dsl.ml
+++ b/src/array/lin_tests_dsl.ml
@@ -1,0 +1,35 @@
+(* ********************************************************************** *)
+(*                      Tests of thread-unsafe [Array]                    *)
+(* ********************************************************************** *)
+module AConf =
+struct
+  type t = char array
+
+  let array_size = 16
+  let init () = Array.make array_size 'a'
+  let cleanup _ = ()
+
+  open Lin_api
+  let int,char = nat_small,char_printable
+  let array_to_seq a = List.to_seq (List.of_seq (Array.to_seq a)) (* workaround: Array.to_seq is lazy and will otherwise see and report later Array.set state changes... *)
+  let api =
+    [ val_ "Array.length"   Array.length   (t @-> returning int);
+      val_ "Array.get"      Array.get      (t @-> int @-> returning_or_exc char);
+      val_ "Array.set"      Array.set      (t @-> int @-> char @-> returning_or_exc unit);
+      val_ "Array.sub"      Array.sub      (t @-> int @-> int @-> returning_or_exc (array char));
+      val_ "Array.copy"     Array.copy     (t @-> returning (array char));
+      val_ "Array.fill"     Array.fill     (t @-> int @-> int @-> char @-> returning_or_exc unit);
+      val_ "Array.to_list"  Array.to_list  (t @-> returning (list char));
+      val_ "Array.mem"      Array.mem      (char @-> t @-> returning bool);
+      val_ "Array.sort"     (Array.sort Char.compare) (t @-> returning unit);
+      val_ "Array.to_seq"   array_to_seq   (t @-> returning (seq char));
+    ]
+end
+
+module AT = Lin_api.Make(AConf)
+;;
+Util.set_ci_printing ()
+;;
+QCheck_runner.run_tests_main [
+  AT.neg_lin_test `Domain ~count:1000 ~name:"Array DSL test";
+]


### PR DESCRIPTION
This PR adds `Lin` and `Lin_api` tests of (parts of) the `Array` module.
To do so, it adds missing `array` and `seq` combinators to `Lin_api`.
Finally it updates the test overview in src/README.md.