### PR TITLE
Adjust Ephemeron string distribution in lin_api tests

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -37,6 +37,8 @@ let int64 =          GenDeconstr (QCheck.int64,          Int64.to_string,   Int6
 let nat64_small =    GenDeconstr (qcheck_nat64_small,    Int64.to_string,   Int64.equal)
 let float =          GenDeconstr (QCheck.float,          Float.to_string,   Float.equal)
 let string =         GenDeconstr (QCheck.string,         print_string,      String.equal)
+let string_small =   GenDeconstr (QCheck.small_string,   print_string,      String.equal)
+let string_small_printable = GenDeconstr (QCheck.small_printable_string,   print_string,      String.equal)
 
 let option : type a c s. ?ratio:float -> (a, c, s, combinable) ty -> (a option, c, s, combinable) ty =
   fun ?ratio ty ->

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -25,6 +25,8 @@ val int64 : (Int64.t, 'a, 'b, combinable) ty
 val nat64_small : (Int64.t, 'a, 'b, combinable) ty
 val float : (float, 'a, 'b, combinable) ty
 val string : (String.t, 'a, 'b, combinable) ty
+val string_small : (String.t, 'a, 'b, combinable) ty
+val string_small_printable : (String.t, 'a, 'b, combinable) ty
 
 val option :
   ?ratio:float ->

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -23,7 +23,7 @@ module EConf =
     let cleanup _ = ()
 
     open Lin_api
-    let int = nat_small
+    let int,string = nat_small, string_small_printable
     let api =
       [ val_ "Ephemeron.clear"    E.clear    (t @-> returning unit);
         val_ "Ephemeron.add"      E.add      (t @-> int @-> string @-> returning unit);


### PR DESCRIPTION
This PR adjusts the `string` distribution in the `Ephemeron` `Lin_api` tests to generate smaller strings - which will hopefully shrink faster.
To do so, we add `string_small` and `string_small_printable` combinators.