### PR TITLE
Avoid implicit test name prefixing and suffixing

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -166,7 +166,7 @@ struct
   (** A generator of command sequences. Accepts the initial state as parameter. *)
 
   let consistency_test ~count ~name =
-    Test.make ~name:name ~count:count (arb_cmds Spec.init_state) (cmds_ok Spec.init_state)
+    Test.make ~name ~count (arb_cmds Spec.init_state) (cmds_ok Spec.init_state)
   (** A consistency test that generates a number of [cmd] sequences and
       checks that all contained [cmd]s satisfy the precondition [precond].
       Accepts two labeled parameters:
@@ -219,12 +219,12 @@ struct
       Cleans up after itself by calling [Spec.cleanup] *)
 
   let agree_test ~count ~name =
-    Test.make ~name:("sequential " ^ name) ~count (arb_cmds Spec.init_state) agree_prop
+    Test.make ~name ~count (arb_cmds Spec.init_state) agree_prop
   (** An actual agreement test (for convenience). Accepts two labeled parameters:
       [count] is the test count and [name] is the printed test name. *)
 
    let neg_agree_test ~count ~name =
-    Test.make_neg ~name:("sequential " ^ name) ~count (arb_cmds Spec.init_state) agree_prop
+    Test.make_neg ~name ~count (arb_cmds Spec.init_state) agree_prop
   (** An negative agreement test (for convenience). Accepts two labeled parameters:
       [count] is the test count and [name] is the printed test name. *)
 
@@ -391,7 +391,7 @@ struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make ~retries:15 ~max_gen ~count ~name:("parallel " ^ name)
+    Test.make ~retries:15 ~max_gen ~count ~name
       (arb_cmds_par seq_len par_len)
       (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
 
@@ -400,7 +400,7 @@ struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make_neg ~retries:15 ~max_gen ~count ~name:("parallel " ^ name)
+    Test.make_neg ~retries:15 ~max_gen ~count ~name
       (arb_cmds_par seq_len par_len)
       (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
 end

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -288,18 +288,18 @@ module Make(Spec : CmdSpec)
     | `Domain ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 50 in
-        Test.make ~count ~retries:3 ~name:("Linearizable " ^ name ^ " with Domain")
+        Test.make ~count ~retries:3 ~name
           arb_cmd_triple (repeat rep_count lin_prop_domain)
     | `Thread ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 100 in
-        Test.make ~count ~retries:5 ~name:("Linearizable " ^ name ^ " with Thread")
+        Test.make ~count ~retries:5 ~name
           arb_cmd_triple (repeat rep_count lin_prop_thread)
     | `Effect ->
         (* this generator is over [EffSpec.cmd] including [SchedYield], not [Spec.cmd] like the above two *)
         let arb_cmd_triple = EffTest.arb_cmds_par seq_len par_len in
         let rep_count = 1 in
-        Test.make ~count ~retries:10 ~name:("Linearizable " ^ name ^ " with Effect")
+        Test.make ~count ~retries:10 ~name
           arb_cmd_triple (repeat rep_count lin_prop_effect)
 
   (* Negative linearizability test based on [Domain], [Thread], or [Effect] *)
@@ -309,17 +309,17 @@ module Make(Spec : CmdSpec)
     | `Domain ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 50 in
-        Test.make_neg ~count ~retries:3 ~name:("Linearizable " ^ name ^ " with Domain")
+        Test.make_neg ~count ~retries:3 ~name
           arb_cmd_triple (repeat rep_count lin_prop_domain)
     | `Thread ->
         let arb_cmd_triple = arb_cmds_par seq_len par_len in
         let rep_count = 100 in
-        Test.make_neg ~count ~retries:5 ~name:("Linearizable " ^ name ^ " with Thread")
+        Test.make_neg ~count ~retries:5 ~name
           arb_cmd_triple (repeat rep_count lin_prop_thread)
     | `Effect ->
         (* this generator is over [EffSpec.cmd] including [SchedYield], not [Spec.cmd] like the above two *)
         let arb_cmd_triple = EffTest.arb_cmds_par seq_len par_len in
         let rep_count = 1 in
-        Test.make_neg ~count ~retries:10 ~name:("Linearizable " ^ name ^ " with Effect")
+        Test.make_neg ~count ~retries:10 ~name
           arb_cmd_triple (repeat rep_count lin_prop_effect)
 end

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -61,5 +61,5 @@ module AT = Lin.Make(AConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  AT.neg_lin_test `Domain ~count:1000 ~name:"Array test";
+  AT.neg_lin_test `Domain ~count:1000 ~name:"Lin Array test with Domain";
 ]

--- a/src/array/lin_tests_dsl.ml
+++ b/src/array/lin_tests_dsl.ml
@@ -31,5 +31,5 @@ module AT = Lin_api.Make(AConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  AT.neg_lin_test `Domain ~count:1000 ~name:"Array DSL test";
+  AT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Array test with Domain";
 ]

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -111,6 +111,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [ArraySTM.agree_test         ~count ~name:"Array test sequential";
-    ArraySTM.neg_agree_test_par ~count ~name:"Array test parallel" (* this test is expected to fail *)
+   [ArraySTM.agree_test         ~count ~name:"STM Array test sequential";
+    ArraySTM.neg_agree_test_par ~count ~name:"STM Array test parallel" (* this test is expected to fail *)
 ])

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -111,6 +111,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [ArraySTM.agree_test         ~count ~name:"array test";
-    ArraySTM.neg_agree_test_par ~count ~name:"array test parallel" (* this test is expected to fail *)
+   [ArraySTM.agree_test         ~count ~name:"Array test sequential";
+    ArraySTM.neg_agree_test_par ~count ~name:"Array test parallel" (* this test is expected to fail *)
 ])

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -90,6 +90,6 @@ module A3T = Lin.Make(A3Conf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  AT.lin_test     `Domain ~count:1000 ~name:"Atomic test with domains";
-  A3T.lin_test    `Domain ~count:1000 ~name:"Atomic3 test with domains";
+  AT.lin_test     `Domain ~count:1000 ~name:"Lin Atomic test with Domain";
+  A3T.lin_test    `Domain ~count:1000 ~name:"Lin Atomic3 test with Domain";
 ]

--- a/src/atomic/lin_tests_dsl.ml
+++ b/src/atomic/lin_tests_dsl.ml
@@ -18,5 +18,5 @@ module Lin_atomic = Lin_api.Make (Atomic_spec)
 let () = Util.set_ci_printing ()
 let () =
   QCheck_runner.run_tests_main
-    [ Lin_atomic.lin_test ~count:1000 ~name:"Atomic" `Domain;
+    [ Lin_atomic.lin_test `Domain ~count:1000 ~name:"Lin_api Atomic test with Domain";
     ]

--- a/src/atomic/stm_tests.ml
+++ b/src/atomic/stm_tests.ml
@@ -71,6 +71,6 @@ module AT = STM.Make(CConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count,name = 1000,"atomic test" in
-   [AT.agree_test     ~count ~name;
-    AT.agree_test_par ~count ~name;])
+  (let count = 1000 in
+   [AT.agree_test     ~count ~name:"Atomic test sequential";
+    AT.agree_test_par ~count ~name:"Atomic test parallel";])

--- a/src/atomic/stm_tests.ml
+++ b/src/atomic/stm_tests.ml
@@ -72,5 +72,5 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [AT.agree_test     ~count ~name:"Atomic test sequential";
-    AT.agree_test_par ~count ~name:"Atomic test parallel";])
+   [AT.agree_test     ~count ~name:"STM Atomic test sequential";
+    AT.agree_test_par ~count ~name:"STM Atomic test parallel";])

--- a/src/buffer/stm_tests.ml
+++ b/src/buffer/stm_tests.ml
@@ -132,5 +132,5 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [BufferSTM.agree_test         ~count ~name:"Buffer test sequential";
-    BufferSTM.neg_agree_test_par ~count ~name:"Buffer test parallel" (* this test is expected to fail *)])
+   [BufferSTM.agree_test         ~count ~name:"STM Buffer test sequential";
+    BufferSTM.neg_agree_test_par ~count ~name:"STM Buffer test parallel" (* this test is expected to fail *)])

--- a/src/buffer/stm_tests.ml
+++ b/src/buffer/stm_tests.ml
@@ -132,5 +132,5 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [BufferSTM.agree_test         ~count ~name:"buffer test";         (* this test is expected to succeed *)
-    BufferSTM.neg_agree_test_par ~count ~name:"buffer test parallel" (* this test is expected to fail *)])
+   [BufferSTM.agree_test         ~count ~name:"Buffer test sequential";
+    BufferSTM.neg_agree_test_par ~count ~name:"Buffer test parallel" (* this test is expected to fail *)])

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -21,6 +21,6 @@ module BT = Lin_api.Make(BConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  BT.lin_test `Domain ~count:1000 ~name:"Bytes test";
-  BT.lin_test `Thread ~count:1000 ~name:"Bytes test";
+  BT.lin_test `Domain ~count:1000 ~name:"Lin_api Bytes test with Domain";
+  BT.lin_test `Thread ~count:1000 ~name:"Lin_api Bytes test with Thread";
 ]

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -43,6 +43,6 @@ module ET = Lin_api.Make(EConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-    ET.neg_lin_test `Domain ~count:1000 ~name:"Ephemeron test with domains";
-    ET.lin_test     `Thread ~count:1000 ~name:"Ephemeron test with threads";
+    ET.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Ephemeron test with Domain";
+    ET.lin_test     `Thread ~count:1000 ~name:"Lin_api Ephemeron test with Thread";
   ]

--- a/src/ephemeron/stm_tests.ml
+++ b/src/ephemeron/stm_tests.ml
@@ -139,7 +139,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [ ETest.agree_test         ~count ~name:"Ephemeron test sequential"; (* succeed *)
-     ETest.neg_agree_test_par ~count ~name:"Ephemeron test parallel";   (* fail *)
+   [ ETest.agree_test         ~count ~name:"STM Ephemeron test sequential"; (* succeed *)
+     ETest.neg_agree_test_par ~count ~name:"STM Ephemeron test parallel";   (* fail *)
   ])
 

--- a/src/ephemeron/stm_tests.ml
+++ b/src/ephemeron/stm_tests.ml
@@ -138,8 +138,8 @@ module ETest = STM.Make(EphemeronModel)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count,name = 1000,"Ephemeron test" in
-   [ ETest.agree_test         ~count ~name; (* succeed *)
-     ETest.neg_agree_test_par ~count ~name; (* fail *)
+  (let count = 1000 in
+   [ ETest.agree_test         ~count ~name:"Ephemeron test sequential"; (* succeed *)
+     ETest.neg_agree_test_par ~count ~name:"Ephemeron test parallel";   (* fail *)
   ])
 

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -70,5 +70,5 @@ module HT = Lin.Make(HConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  HT.neg_lin_test     `Domain ~count:1000 ~name:"Hashtbl test with domains";
+  HT.neg_lin_test     `Domain ~count:1000 ~name:"Lin Hashtbl test with Domain";
 ]

--- a/src/hashtbl/lin_tests_dsl.ml
+++ b/src/hashtbl/lin_tests_dsl.ml
@@ -28,5 +28,5 @@ module HT = Lin_api.Make(HConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  HT.neg_lin_test `Domain ~count:1000 ~name:"Hashtbl DSL test";
+  HT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Hashtbl test with Domain";
 ]

--- a/src/hashtbl/stm_tests.ml
+++ b/src/hashtbl/stm_tests.ml
@@ -123,6 +123,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 200 in
-   [HTest.agree_test       ~count ~name:"Hashtbl test sequential";
-    HTest.agree_test_par   ~count ~name:"Hashtbl test parallel";
+   [HTest.agree_test       ~count ~name:"STM Hashtbl test sequential";
+    HTest.agree_test_par   ~count ~name:"STM Hashtbl test parallel";
    ])

--- a/src/hashtbl/stm_tests.ml
+++ b/src/hashtbl/stm_tests.ml
@@ -123,6 +123,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 200 in
-   [HTest.agree_test       ~count ~name:"Hashtbl test";
-    HTest.agree_test_par   ~count ~name:"Hashtbl test";
+   [HTest.agree_test       ~count ~name:"Hashtbl test sequential";
+    HTest.agree_test_par   ~count ~name:"Hashtbl test parallel";
    ])

--- a/src/kcas/lin_tests.ml
+++ b/src/kcas/lin_tests.ml
@@ -114,6 +114,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
   (* Kcas tests *)
-  KT.neg_lin_test `Domain ~count:1000 ~name:"Kcas test";
-  KW1T.lin_test   `Domain ~count:1000 ~name:"Kcas.W1 test";
+  KT.neg_lin_test `Domain ~count:1000 ~name:"Lin Kcas test with Domain";
+  KW1T.lin_test   `Domain ~count:1000 ~name:"Lin Kcas.W1 test with Domain";
 ]

--- a/src/kcas/lin_tests_dsl.ml
+++ b/src/kcas/lin_tests_dsl.ml
@@ -78,6 +78,6 @@ module KW1T = Lin_api.Make(KW1Conf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-  KT.neg_lin_test `Domain ~count:1000 ~name:"Kcas test";
-  KW1T.lin_test   `Domain ~count:1000 ~name:"Kcas.W1 test";
+  KT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Kcas test with Domain";
+  KW1T.lin_test   `Domain ~count:1000 ~name:"Lin_api Kcas.W1 test with Domain";
 ]

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -92,7 +92,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 100 in
-   [LTlazy.neg_lin_test       `Domain ~count ~name:"lazy test";
-    LTfromval.lin_test        `Domain ~count ~name:"lazy test from_val";
-    LTfromfun.neg_lin_test    `Domain ~count ~name:"lazy test from_fun";
+   [LTlazy.neg_lin_test       `Domain ~count ~name:"Lin Lazy test with Domain";
+    LTfromval.lin_test        `Domain ~count ~name:"Lin Lazy test with Domain from_val";
+    LTfromfun.neg_lin_test    `Domain ~count ~name:"Lin Lazy test with Domain from_fun";
    ])

--- a/src/lazy/lin_tests_dsl.ml
+++ b/src/lazy/lin_tests_dsl.ml
@@ -69,7 +69,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 100 in
-   [LTlazy.neg_lin_test    `Domain ~count ~name:"lazy test";
-    LTfromval.lin_test     `Domain ~count ~name:"lazy test from_val";
-    LTfromfun.neg_lin_test `Domain ~count ~name:"lazy test from_fun";
+   [LTlazy.neg_lin_test    `Domain ~count ~name:"Lin_api Lazy test with Domain";
+    LTfromval.lin_test     `Domain ~count ~name:"Lin_api Lazy test with Domain from_val";
+    LTfromfun.neg_lin_test `Domain ~count ~name:"Lin_api Lazy test with Domain from_fun";
    ])

--- a/src/lazy/stm_tests.ml
+++ b/src/lazy/stm_tests.ml
@@ -117,10 +117,10 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 200 in
-   [LTlazy.agree_test        ~count ~name:"Lazy test sequential";
-    LTfromval.agree_test     ~count ~name:"Lazy test sequential from_val";
-    LTfromfun.agree_test     ~count ~name:"Lazy test sequential from_fun";
-    LTlazy.neg_agree_test_par    ~count ~name:"Lazy test parallel";
-    LTfromval.agree_test_par     ~count ~name:"Lazy test parallel from_val";
-    LTfromfun.neg_agree_test_par ~count ~name:"Lazy test parallel from_fun";
+   [LTlazy.agree_test        ~count ~name:"STM Lazy test sequential";
+    LTfromval.agree_test     ~count ~name:"STM Lazy test sequential from_val";
+    LTfromfun.agree_test     ~count ~name:"STM Lazy test sequential from_fun";
+    LTlazy.neg_agree_test_par    ~count ~name:"STM Lazy test parallel";
+    LTfromval.agree_test_par     ~count ~name:"STM Lazy test parallel from_val";
+    LTfromfun.neg_agree_test_par ~count ~name:"STM Lazy test parallel from_fun";
    ])

--- a/src/lazy/stm_tests.ml
+++ b/src/lazy/stm_tests.ml
@@ -117,10 +117,10 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 200 in
-   [LTlazy.agree_test        ~count ~name:"lazy test";
-    LTfromval.agree_test     ~count ~name:"lazy test from_val";
-    LTfromfun.agree_test     ~count ~name:"lazy test from_fun";
-    LTlazy.neg_agree_test_par    ~count ~name:"lazy test";
-    LTfromval.agree_test_par     ~count ~name:"lazy test from_val";
-    LTfromfun.neg_agree_test_par ~count ~name:"lazy test from_fun";
+   [LTlazy.agree_test        ~count ~name:"Lazy test sequential";
+    LTfromval.agree_test     ~count ~name:"Lazy test sequential from_val";
+    LTfromfun.agree_test     ~count ~name:"Lazy test sequential from_fun";
+    LTlazy.neg_agree_test_par    ~count ~name:"Lazy test parallel";
+    LTfromval.agree_test_par     ~count ~name:"Lazy test parallel from_val";
+    LTfromfun.neg_agree_test_par ~count ~name:"Lazy test parallel from_fun";
    ])

--- a/src/neg_tests/conclist_stm_tests.ml
+++ b/src/neg_tests/conclist_stm_tests.ml
@@ -56,7 +56,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [CLT_int.agree_test       ~count ~name:"int CList test sequential";
-    CLT_int64.agree_test     ~count ~name:"int64 CList test sequential";
-    CLT_int.neg_agree_test_par   ~count ~name:"int CList test parallel";
-    CLT_int64.neg_agree_test_par ~count ~name:"int64 CList test parallel"])
+   [CLT_int.agree_test       ~count ~name:"STM int CList test sequential";
+    CLT_int64.agree_test     ~count ~name:"STM int64 CList test sequential";
+    CLT_int.neg_agree_test_par   ~count ~name:"STM int CList test parallel";
+    CLT_int64.neg_agree_test_par ~count ~name:"STM int64 CList test parallel"])

--- a/src/neg_tests/conclist_stm_tests.ml
+++ b/src/neg_tests/conclist_stm_tests.ml
@@ -56,7 +56,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [CLT_int.agree_test       ~count ~name:"int CList test";
-    CLT_int64.agree_test     ~count ~name:"int64 CList test";
-    CLT_int.neg_agree_test_par   ~count ~name:"int CList test";
-    CLT_int64.neg_agree_test_par ~count ~name:"int64 CList test"])
+   [CLT_int.agree_test       ~count ~name:"int CList test sequential";
+    CLT_int64.agree_test     ~count ~name:"int64 CList test sequential";
+    CLT_int.neg_agree_test_par   ~count ~name:"int CList test parallel";
+    CLT_int64.neg_agree_test_par ~count ~name:"int64 CList test parallel"])

--- a/src/neg_tests/domain_lin_tests.ml
+++ b/src/neg_tests/domain_lin_tests.ml
@@ -7,7 +7,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.neg_lin_test    `Domain ~count ~name:"ref int test";
-    RT_int64.neg_lin_test  `Domain ~count ~name:"ref int64 test";
-    CLT_int.neg_lin_test   `Domain ~count ~name:"CList int test";
-    CLT_int64.neg_lin_test `Domain ~count ~name:"CList int64 test"])
+   [RT_int.neg_lin_test    `Domain ~count ~name:"Lin ref int test with Domain";
+    RT_int64.neg_lin_test  `Domain ~count ~name:"Lin ref int64 test with Domain";
+    CLT_int.neg_lin_test   `Domain ~count ~name:"Lin CList int test with Domain";
+    CLT_int64.neg_lin_test `Domain ~count ~name:"Lin CList int64 test with Domain"])

--- a/src/neg_tests/domain_lin_tests_dsl.ml
+++ b/src/neg_tests/domain_lin_tests_dsl.ml
@@ -7,7 +7,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 10000 in
-   [RT_int.neg_lin_test    `Domain ~count ~name:"ref int test";
-    RT_int64.neg_lin_test  `Domain ~count ~name:"ref int64 test";
-    CLT_int.neg_lin_test   `Domain ~count ~name:"CList int test";
-    CLT_int64.neg_lin_test `Domain ~count ~name:"CList int64 test"])
+   [RT_int.neg_lin_test    `Domain ~count ~name:"Lin_api ref int test with Domain";
+    RT_int64.neg_lin_test  `Domain ~count ~name:"Lin_api ref int64 test with Domain";
+    CLT_int.neg_lin_test   `Domain ~count ~name:"Lin_api CList int test with Domain";
+    CLT_int64.neg_lin_test `Domain ~count ~name:"Lin_api CList int64 test with Domain"])

--- a/src/neg_tests/effect_lin_tests.ml
+++ b/src/neg_tests/effect_lin_tests.ml
@@ -62,13 +62,13 @@ Util.set_ci_printing ()
 QCheck_runner.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
-      RT_int.lin_test     `Effect ~count ~name:"ref int test";
-      RT_int64.lin_test   `Effect ~count ~name:"ref int64 test";
-      CLT_int.lin_test    `Effect ~count ~name:"CList int test";
-      CLT_int64.lin_test  `Effect ~count ~name:"CList int64 test";
+      RT_int.lin_test     `Effect ~count ~name:"Lin ref int test with Effect";
+      RT_int64.lin_test   `Effect ~count ~name:"Lin ref int64 test with Effect";
+      CLT_int.lin_test    `Effect ~count ~name:"Lin CList int test with Effect";
+      CLT_int64.lin_test  `Effect ~count ~name:"Lin CList int64 test with Effect";
       (* These next four tests are negative - and are expected to fail with exception `Unhandled` *)
-      RT_int'.neg_lin_test    `Effect ~count ~name:"negative ref int test";
-      RT_int64'.neg_lin_test  `Effect ~count ~name:"negative ref int64 test";
-      CLT_int'.neg_lin_test   `Effect ~count ~name:"negative CList int test";
-      CLT_int64'.neg_lin_test `Effect ~count ~name:"negative CList int64 test"
+      RT_int'.neg_lin_test    `Effect ~count ~name:"negative Lin ref int test with Effect";
+      RT_int64'.neg_lin_test  `Effect ~count ~name:"negative Lin ref int64 test with Effect";
+      CLT_int'.neg_lin_test   `Effect ~count ~name:"negative Lin CList int test with Effect";
+      CLT_int64'.neg_lin_test `Effect ~count ~name:"negative Lin CList int64 test with Effect"
     ])

--- a/src/neg_tests/effect_lin_tests_dsl.ml
+++ b/src/neg_tests/effect_lin_tests_dsl.ml
@@ -81,13 +81,13 @@ Util.set_ci_printing ()
 QCheck_runner.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
-      RT_int.lin_test     `Effect ~count ~name:"ref int test";
-      RT_int64.lin_test   `Effect ~count ~name:"ref int64 test";
-      CLT_int.lin_test    `Effect ~count ~name:"CList int test";
-      CLT_int64.lin_test  `Effect ~count ~name:"CList int64 test";
+      RT_int.lin_test     `Effect ~count ~name:"Lin_api ref int test with Effect";
+      RT_int64.lin_test   `Effect ~count ~name:"Lin_api ref int64 test with Effect";
+      CLT_int.lin_test    `Effect ~count ~name:"Lin_api CList int test with Effect";
+      CLT_int64.lin_test  `Effect ~count ~name:"Lin_api CList int64 test with Effect";
       (* These next four tests are negative - and are expected to fail with exception `Unhandled` *)
-      RT_int'.neg_lin_test    `Effect ~count ~name:"negative ref int test";
-      RT_int64'.neg_lin_test  `Effect ~count ~name:"negative ref int64 test";
-      CLT_int'.neg_lin_test   `Effect ~count ~name:"negative CList int test";
-      CLT_int64'.neg_lin_test `Effect ~count ~name:"negative CList int64 test"
+      RT_int'.neg_lin_test    `Effect ~count ~name:"negative Lin_api ref int test with Effect";
+      RT_int64'.neg_lin_test  `Effect ~count ~name:"negative Lin_api ref int64 test with Effect";
+      CLT_int'.neg_lin_test   `Effect ~count ~name:"negative Lin_api CList int test with Effect";
+      CLT_int64'.neg_lin_test `Effect ~count ~name:"negative Lin_api CList int64 test with Effect"
     ])

--- a/src/neg_tests/ref_stm_tests.ml
+++ b/src/neg_tests/ref_stm_tests.ml
@@ -147,10 +147,10 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.agree_test            ~count ~name:"global int ref test";
-    RT_int.neg_agree_test_par    ~count ~name:"global int ref test";
-    RT_int_GC.neg_agree_test_par ~count ~name:"global int ref test (w/AddGC functor)";
-    RT_int.agree_test            ~count ~name:"global int64 ref test";
-    RT_int.neg_agree_test_par    ~count ~name:"global int64 ref test";
-    RT_int_GC.neg_agree_test_par ~count ~name:"global int64 ref test (w/AddGC functor)";
+   [RT_int.agree_test            ~count ~name:"int ref test sequential";
+    RT_int.neg_agree_test_par    ~count ~name:"int ref test parallel";
+    RT_int_GC.neg_agree_test_par ~count ~name:"int ref test parallel (w/AddGC functor)";
+    RT_int.agree_test            ~count ~name:"int64 ref test sequential";
+    RT_int.neg_agree_test_par    ~count ~name:"int64 ref test parallel";
+    RT_int_GC.neg_agree_test_par ~count ~name:"int64 ref test parallel (w/AddGC functor)";
    ])

--- a/src/neg_tests/ref_stm_tests.ml
+++ b/src/neg_tests/ref_stm_tests.ml
@@ -147,10 +147,10 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.agree_test            ~count ~name:"int ref test sequential";
-    RT_int.neg_agree_test_par    ~count ~name:"int ref test parallel";
-    RT_int_GC.neg_agree_test_par ~count ~name:"int ref test parallel (w/AddGC functor)";
-    RT_int.agree_test            ~count ~name:"int64 ref test sequential";
-    RT_int.neg_agree_test_par    ~count ~name:"int64 ref test parallel";
-    RT_int_GC.neg_agree_test_par ~count ~name:"int64 ref test parallel (w/AddGC functor)";
+   [RT_int.agree_test            ~count ~name:"STM int ref test sequential";
+    RT_int.neg_agree_test_par    ~count ~name:"STM int ref test parallel";
+    RT_int_GC.neg_agree_test_par ~count ~name:"STM int ref test parallel (w/AddGC functor)";
+    RT_int.agree_test            ~count ~name:"STM int64 ref test sequential";
+    RT_int.neg_agree_test_par    ~count ~name:"STM int64 ref test parallel";
+    RT_int_GC.neg_agree_test_par ~count ~name:"STM int64 ref test parallel (w/AddGC functor)";
    ])

--- a/src/neg_tests/thread_lin_tests.ml
+++ b/src/neg_tests/thread_lin_tests.ml
@@ -7,7 +7,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.lin_test        `Thread ~count ~name:"ref int test";   (* unboxed, hence no allocations to trigger context switch *)
-    RT_int64.neg_lin_test  `Thread ~count ~name:"ref int64 test";
-    CLT_int.lin_test       `Thread ~count ~name:"CList int test"; (* unboxed, hence no allocations to trigger context switch *)
-    CLT_int64.lin_test `Thread ~count ~name:"CList int64 test"])  (* not triggering context switch, unfortunately *)
+   [RT_int.lin_test       `Thread ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+    RT_int64.neg_lin_test `Thread ~count ~name:"Lin ref int64 test with Thread";
+    CLT_int.lin_test      `Thread ~count ~name:"Lin CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+    CLT_int64.lin_test    `Thread ~count ~name:"Lin CList int64 test with Thread"]) (* not triggering context switch, unfortunately *)

--- a/src/neg_tests/thread_lin_tests_dsl.ml
+++ b/src/neg_tests/thread_lin_tests_dsl.ml
@@ -7,7 +7,7 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.lin_test       `Thread ~count ~name:"ref int test";
-    RT_int64.neg_lin_test `Thread ~count ~name:"ref int64 test";
-    CLT_int.lin_test      `Thread ~count ~name:"CList int test";
-    CLT_int64.lin_test    `Thread ~count ~name:"CList int64 test"])
+   [RT_int.lin_test       `Thread ~count ~name:"Lin_api ref int test with Thread";
+    RT_int64.neg_lin_test `Thread ~count ~name:"Lin_api ref int64 test with Thread";
+    CLT_int.lin_test      `Thread ~count ~name:"Lin_api CList int test with Thread";
+    CLT_int64.lin_test    `Thread ~count ~name:"Lin_api CList int64 test with Thread"])

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -111,8 +111,8 @@ module QT  = Lin.Make(QConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-    QMT.lin_test    `Domain ~count:1000 ~name:"Queue test with domains and mutex";
-    QMT.lin_test    `Thread ~count:1000 ~name:"Queue test with threads and mutex";
-    QT.neg_lin_test `Domain ~count:1000 ~name:"Queue test with domains without mutex";
-    QT.lin_test     `Thread ~count:1000 ~name:"Queue test with threads without mutex";
+    QMT.lin_test    `Domain ~count:1000 ~name:"Lin Queue test with Domain and mutex";
+    QMT.lin_test    `Thread ~count:1000 ~name:"Lin Queue test with Thread and mutex";
+    QT.neg_lin_test `Domain ~count:1000 ~name:"Lin Queue test with Domain without mutex";
+    QT.lin_test     `Thread ~count:1000 ~name:"Lin Queue test with Thread without mutex";
   ]

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -19,8 +19,8 @@ end
 module Lin_queue = Lin_api.Make(Queue_spec)
 
 let () =
-  let count,name = 1000,"Queue test" in
+  let count = 1000 in
   QCheck_runner.run_tests_main [
-    Lin_queue.neg_lin_test ~count ~name `Domain;
-    Lin_queue.lin_test     ~count ~name `Thread;
+    Lin_queue.neg_lin_test `Domain ~count ~name:"Lin_api Queue test with Domain";
+    Lin_queue.lin_test     `Thread ~count ~name:"Lin_api Queue test with Thread";
   ]

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -111,8 +111,8 @@ module SMT = Lin.Make(SMutexConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
-    SMT.lin_test    `Domain ~count:1000 ~name:"Stack test with domains and mutex";
-    SMT.lin_test    `Thread ~count:1000 ~name:"Stack test with threads and mutex";
-    ST.neg_lin_test `Domain ~count:1000 ~name:"Stack test with domains without mutex";
-    ST.lin_test     `Thread ~count:1000 ~name:"Stack test with threads without mutex";
+    SMT.lin_test    `Domain ~count:1000 ~name:"Lin Stack test with Domain and mutex";
+    SMT.lin_test    `Thread ~count:1000 ~name:"Lin Stack test with Thread and mutex";
+    ST.neg_lin_test `Domain ~count:1000 ~name:"Lin Stack test with Domain without mutex";
+    ST.lin_test     `Thread ~count:1000 ~name:"Lin Stack test with Thread without mutex";
   ]

--- a/src/stack/lin_tests_dsl.ml
+++ b/src/stack/lin_tests_dsl.ml
@@ -19,8 +19,8 @@ module Stack_spec : Lin_api.ApiSpec = struct
 module Lin_stack = Lin_api.Make(Stack_spec)
 
 let () =
-  let count,name = 1000,"Stack test" in
+  let count = 1000 in
   QCheck_runner.run_tests_main [
-      Lin_stack.neg_lin_test ~count ~name `Domain;
-      Lin_stack.lin_test     ~count ~name `Thread;
+      Lin_stack.neg_lin_test `Domain ~count ~name:"Lin_api Stack test with Domain";
+      Lin_stack.lin_test     `Thread ~count ~name:"Lin_api Stack test with Thread";
     ]


### PR DESCRIPTION
This PR cleans up the "test name cleverness" that previously would insert a prefix `"Linerizable "` or a suffix `" with Domain"` in favor of passing a test `~name` unmodified.
We thus avoid implicit name manipulation and allow users to set test names to their liking.

The majority of the PR changes update the `STM`, `Lin`, and `Lin_api` tests with relatively consistent names...