### PR TITLE
Save CI time

### DIFF
--- a/src/atomic/stm_tests.ml
+++ b/src/atomic/stm_tests.ml
@@ -71,6 +71,6 @@ module AT = STM.Make(CConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count = 1000 in
+  (let count = 250 in
    [AT.agree_test     ~count ~name:"STM Atomic test sequential";
     AT.agree_test_par ~count ~name:"STM Atomic test parallel";])

--- a/src/domain/domain_spawntree.ml
+++ b/src/domain/domain_spawntree.ml
@@ -73,7 +73,7 @@ let rec dom_interp a = function
 
 let t ~max_depth ~max_width = Test.make
     ~name:"domain_spawntree - with Atomic"
-    ~count:250
+    ~count:100
     ~retries:100
     (*~print:show_cmd (gen max_depth max_width)*)
     (make ~print:show_cmd ~shrink:shrink_cmd (gen max_depth max_width))

--- a/src/domainslib/chan_stm_tests.ml
+++ b/src/domainslib/chan_stm_tests.ml
@@ -74,7 +74,7 @@ module ChT = STM.Make(ChConf)
 Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
-  (let count,name = 1000,"global Domainslib.Chan test" in [
+  (let count,name = 500,"global Domainslib.Chan test" in [
       ChT.agree_test     ~count ~name;
       ChT.agree_test_par ~count ~name;
     ])

--- a/src/domainslib/task_parallel.ml
+++ b/src/domainslib/task_parallel.ml
@@ -16,8 +16,11 @@ let scan_task num_doms array_size =
   Task.teardown_pool pool;
   a
 *)
+
+let count = 500
+
 let test_parallel_for =
-  Test.make ~name:"test Task.parallel_for" ~count:1000
+  Test.make ~name:"test Task.parallel_for" ~count
     (triple (int_bound 10) small_nat small_nat)
     (fun (num_domains,array_size,chunk_size) ->
        (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)
@@ -30,7 +33,7 @@ let test_parallel_for =
        res = array_size)
 
 let test_parallel_for_reduce =
-  Test.make ~name:"test Task.parallel_for_reduce" ~count:1000
+  Test.make ~name:"test Task.parallel_for_reduce" ~count
     (triple (int_bound 10) small_nat small_nat)
     (fun (num_domains,array_size,chunk_size) ->
        (*Printf.printf "(%i,%i,%i)\n%!" num_domains array_size chunk_size;*)
@@ -41,7 +44,7 @@ let test_parallel_for_reduce =
        res = array_size)
 
 let test_parallel_scan =
-  Test.make ~name:"test Task.parallel_scan" ~count:1000
+  Test.make ~name:"test Task.parallel_scan" ~count
     (pair (int_bound 10) small_nat)
     (fun (num_domains,array_size) ->
        (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)

--- a/src/domainslib/task_parallel.ml
+++ b/src/domainslib/task_parallel.ml
@@ -17,7 +17,7 @@ let scan_task num_doms array_size =
   a
 *)
 
-let count = 500
+let count = 250
 
 let test_parallel_for =
   Test.make ~name:"test Task.parallel_for" ~count

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -44,5 +44,5 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
     ET.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Ephemeron test with Domain";
-    ET.lin_test     `Thread ~count:1000 ~name:"Lin_api Ephemeron test with Thread";
+    ET.lin_test     `Thread ~count:500  ~name:"Lin_api Ephemeron test with Thread";
   ]

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -44,5 +44,5 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main [
     ET.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Ephemeron test with Domain";
-    ET.lin_test     `Thread ~count:500  ~name:"Lin_api Ephemeron test with Thread";
+    ET.lin_test     `Thread ~count:250  ~name:"Lin_api Ephemeron test with Thread";
   ]

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -15,14 +15,11 @@
  (libraries qcheck STM)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps stm_tests.exe)
-;  (action
-;   (progn
-;    (bash "(./stm_tests.exe --no-colors --verbose || echo 'test run triggered an error') | tee stm-output.txt")
-;    (run %{bin:check_error_count} "hashtbl/stm_tests" 2 stm-output.txt))))
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps stm_tests.exe)
+ (action (run ./%{deps} --no-colors --verbose)))
 
 
 (executable

--- a/src/hashtbl/stm_tests.ml
+++ b/src/hashtbl/stm_tests.ml
@@ -123,6 +123,6 @@ Util.set_ci_printing ()
 ;;
 QCheck_runner.run_tests_main
   (let count = 200 in
-   [HTest.agree_test       ~count ~name:"STM Hashtbl test sequential";
-    HTest.agree_test_par   ~count ~name:"STM Hashtbl test parallel";
+   [HTest.agree_test         ~count ~name:"STM Hashtbl test sequential";
+    HTest.neg_agree_test_par ~count ~name:"STM Hashtbl test parallel";
    ])

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -36,8 +36,8 @@
  ;(package multicoretests)
  (libraries multicorecheck.lin))
 
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --no-colors --verbose)))
+; (rule
+;  (alias runtest)
+;  (package multicoretests)
+;  (deps lin_tests_dsl.exe)
+;  (action (run ./%{deps} --no-colors --verbose)))

--- a/src/neg_tests/ref_stm_tests.ml
+++ b/src/neg_tests/ref_stm_tests.ml
@@ -149,8 +149,8 @@ QCheck_runner.run_tests_main
   (let count = 1000 in
    [RT_int.agree_test            ~count ~name:"STM int ref test sequential";
     RT_int.neg_agree_test_par    ~count ~name:"STM int ref test parallel";
-    RT_int_GC.neg_agree_test_par ~count ~name:"STM int ref test parallel (w/AddGC functor)";
+  (*RT_int_GC.neg_agree_test_par ~count ~name:"STM int ref test parallel (w/AddGC functor)";*)
     RT_int.agree_test            ~count ~name:"STM int64 ref test sequential";
     RT_int.neg_agree_test_par    ~count ~name:"STM int64 ref test parallel";
-    RT_int_GC.neg_agree_test_par ~count ~name:"STM int64 ref test parallel (w/AddGC functor)";
+  (*RT_int_GC.neg_agree_test_par ~count ~name:"STM int64 ref test parallel (w/AddGC functor)";*)
    ])

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -3,6 +3,7 @@ module Queue_spec : Lin_api.ApiSpec = struct
     type t = int Queue.t
     let init () = Queue.create ()
     let cleanup _ = ()
+    let int = int_small
     let api =
       [ val_ "Queue.add"      Queue.add      (int @-> t @-> returning unit);
         val_ "Queue.take"     Queue.take     (t @-> returning_or_exc int);

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -20,8 +20,7 @@ end
 module Lin_queue = Lin_api.Make(Queue_spec)
 
 let () =
-  let count = 1000 in
   QCheck_runner.run_tests_main [
-    Lin_queue.neg_lin_test `Domain ~count ~name:"Lin_api Queue test with Domain";
-    Lin_queue.lin_test     `Thread ~count ~name:"Lin_api Queue test with Thread";
+    Lin_queue.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Queue test with Domain";
+    Lin_queue.lin_test     `Thread ~count:250  ~name:"Lin_api Queue test with Thread";
   ]

--- a/src/stack/lin_tests_dsl.ml
+++ b/src/stack/lin_tests_dsl.ml
@@ -20,8 +20,7 @@ module Stack_spec : Lin_api.ApiSpec = struct
 module Lin_stack = Lin_api.Make(Stack_spec)
 
 let () =
-  let count = 1000 in
   QCheck_runner.run_tests_main [
-      Lin_stack.neg_lin_test `Domain ~count ~name:"Lin_api Stack test with Domain";
-      Lin_stack.lin_test     `Thread ~count ~name:"Lin_api Stack test with Thread";
+      Lin_stack.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Stack test with Domain";
+      Lin_stack.lin_test     `Thread ~count:250  ~name:"Lin_api Stack test with Thread";
     ]

--- a/src/stack/lin_tests_dsl.ml
+++ b/src/stack/lin_tests_dsl.ml
@@ -3,6 +3,7 @@ module Stack_spec : Lin_api.ApiSpec = struct
     type t = int Stack.t
     let init () = Stack.create ()
     let cleanup _ = ()
+    let int = int_small
     let api =
       [ val_ "Stack.push"     Stack.push (int @-> t @-> returning unit);
         val_ "Stack.pop"      Stack.pop (t @-> returning_or_exc int);


### PR DESCRIPTION
The CI runs are starting to take a long time. On recent `main` I see:
- MacOS: 45m-1h 
- Linux: 1h-1h20m

This PR therefore takes a pass over all the tests triggered by `dune runtest -j1 --no-buffer --display=quiet` in an attempt to reduce the time spent.

In most cases this amounts to reducing test `count` of long-running tests.
In `Stack` and `Queue` `Lin_api` tests most time was spent on shrinking the very large `int` arguments generated - so here changing to a generator of smaller numbers should make a difference.

Fingers crossed that the CI run of this PR show some actual speed-ups... :crossed_fingers: 