### PR TITLE
Reduce qcheck deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 
 module HT = Lin_api.Make(HashtblSig)
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   HT.lin_test `Domain ~count:1000 ~name:"Hashtbl DSL test";
 ]
 ```
@@ -220,7 +220,7 @@ end
 
 module HTest = STM.Make(HashtblModel)
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 200 in
    [HTest.agree_test     ~count ~name:"Hashtbl test";
     HTest.agree_test_par ~count ~name:"Hashtbl test"; ])

--- a/doc/example/dune
+++ b/doc/example/dune
@@ -11,5 +11,5 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck multicorecheck.stm)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+ (libraries multicorecheck.stm)
+ (preprocess (pps ppx_deriving.show)))

--- a/doc/example/lin_tests_dsl.ml
+++ b/doc/example/lin_tests_dsl.ml
@@ -19,6 +19,6 @@ end
 
 module HT = Lin_api.Make(HashtblSig)
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   HT.lin_test `Domain ~count:1000 ~name:"Hashtbl DSL test";
 ]

--- a/doc/example/stm_tests.ml
+++ b/doc/example/stm_tests.ml
@@ -59,7 +59,7 @@ end
 
 module HTest = STM.Make(HashtblModel)
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 200 in
    [HTest.agree_test     ~count ~name:"Hashtbl test";
     HTest.agree_test_par ~count ~name:"Hashtbl test"; ])

--- a/doc/paper-examples/dune
+++ b/doc/paper-examples/dune
@@ -11,5 +11,5 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck multicorecheck.stm)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
+ (libraries multicorecheck.stm)
+ (preprocess (pps ppx_deriving.show)))

--- a/doc/paper-examples/lin_tests_dsl.ml
+++ b/doc/paper-examples/lin_tests_dsl.ml
@@ -23,6 +23,6 @@ end
 
 module HT = Lin_api.Make(HashtblSig)
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   HT.lin_test     `Domain ~count:1000 ~name:"Hashtbl DSL test";
 ]

--- a/doc/paper-examples/stm_tests.ml
+++ b/doc/paper-examples/stm_tests.ml
@@ -70,7 +70,7 @@ end
 
 module HTest = STM.Make(HashtblModel)
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 200 in
    [HTest.agree_test       ~count ~name:"Hashtbl test";
     HTest.agree_test_par   ~count ~name:"Hashtbl test";

--- a/lib/dune
+++ b/lib/dune
@@ -2,17 +2,17 @@
  (name STM)
  (public_name multicorecheck.stm)
  (modules STM)
- (libraries qcheck util))
+ (libraries qcheck-core qcheck-core.runner util))
 
 (library
  (name lin)
  (wrapped false)
  (public_name multicorecheck.lin)
  (modules lin lin_api)
- (libraries threads qcheck util))
+ (libraries threads qcheck-core qcheck-core.runner util))
 
 (library
  (name util)
  (package multicorecheck)
  (modules util)
- (libraries qcheck unix))
+ (libraries qcheck-core.runner unix))

--- a/multicorecheck.opam
+++ b/multicorecheck.opam
@@ -10,7 +10,7 @@ dev-repo:     "git+https://github.com/jmid/multicoretests.git"
 depends: [
   "base-domains"
   "dune"                {>= "2.9.3"}
-  "qcheck"              {>= "0.19"}
+  "qcheck-core"         {>= "0.19"}
   "odoc"                {with-doc}
 ]
 

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -11,17 +11,17 @@ depends: [
   "dune"                {>= "2.9.3"}
   "domainslib"          {>= "0.4.2"}
   "ppx_deriving"        {>= "5.2.1"}
-  "ounit2"              {>= "2.2.6"}
-  "qcheck"              {>= "0.19"}
+# "ounit2"              {>= "2.2.6"}
+  "qcheck-core"         {>= "0.19"}
   "ppx_deriving_qcheck" {>= "0.2.0"}
-  "kcas"                {>= "0.14"}
+# "kcas"                {>= "0.14"}
   "lockfree"            {>= "0.13"}
   "odoc"                {with-doc}
   "multicorecheck"      {= version}
 ]
 pin-depends: [
   ["domainslib.0.4.2"          "git+https://github.com/ocaml-multicore/domainslib#master"]
-  ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
+# ["kcas.0.14"                 "git+https://github.com/ocaml-multicore/kcas#master"]
   ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]
 ]
 

--- a/src/array/dune
+++ b/src/array/dune
@@ -12,7 +12,7 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
+ (libraries STM)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule
@@ -25,7 +25,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule
@@ -37,7 +37,6 @@
 (executable
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- ;(package multicoretests)
  (libraries multicorecheck.lin))
 
 (rule

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -60,6 +60,6 @@ module AT = Lin.Make(AConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   AT.neg_lin_test `Domain ~count:1000 ~name:"Lin Array test with Domain";
 ]

--- a/src/array/lin_tests_dsl.ml
+++ b/src/array/lin_tests_dsl.ml
@@ -30,6 +30,6 @@ module AT = Lin_api.Make(AConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   AT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Array test with Domain";
 ]

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -109,7 +109,7 @@ module ArraySTM = STM.Make(AConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [ArraySTM.agree_test         ~count ~name:"STM Array test sequential";
     ArraySTM.neg_agree_test_par ~count ~name:"STM Array test parallel" (* this test is expected to fail *)

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -12,7 +12,7 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
+ (libraries STM)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule
@@ -28,7 +28,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -89,7 +89,7 @@ module A3T = Lin.Make(A3Conf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   AT.lin_test     `Domain ~count:1000 ~name:"Lin Atomic test with Domain";
   A3T.lin_test    `Domain ~count:1000 ~name:"Lin Atomic3 test with Domain";
 ]

--- a/src/atomic/lin_tests_dsl.ml
+++ b/src/atomic/lin_tests_dsl.ml
@@ -17,6 +17,6 @@ module Lin_atomic = Lin_api.Make (Atomic_spec)
 
 let () = Util.set_ci_printing ()
 let () =
-  QCheck_runner.run_tests_main
+  QCheck_base_runner.run_tests_main
     [ Lin_atomic.lin_test `Domain ~count:1000 ~name:"Lin_api Atomic test with Domain";
     ]

--- a/src/atomic/stm_tests.ml
+++ b/src/atomic/stm_tests.ml
@@ -70,7 +70,7 @@ module AT = STM.Make(CConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 250 in
    [AT.agree_test     ~count ~name:"STM Atomic test sequential";
     AT.agree_test_par ~count ~name:"STM Atomic test parallel";])

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -10,7 +10,7 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
+ (libraries STM)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule

--- a/src/buffer/stm_tests.ml
+++ b/src/buffer/stm_tests.ml
@@ -130,7 +130,7 @@ module BufferSTM = STM.Make(BConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [BufferSTM.agree_test         ~count ~name:"STM Buffer test sequential";
     BufferSTM.neg_agree_test_par ~count ~name:"STM Buffer test parallel" (* this test is expected to fail *)])

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -20,7 +20,7 @@ module BT = Lin_api.Make(BConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   BT.lin_test `Domain ~count:1000 ~name:"Lin_api Bytes test with Domain";
   BT.lin_test `Thread ~count:1000 ~name:"Lin_api Bytes test with Thread";
 ]

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -13,7 +13,7 @@
  (name domain_joingraph)
  (modes native byte)
  (modules domain_joingraph)
- (libraries util qcheck)
+ (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule
@@ -26,7 +26,7 @@
  (name domain_spawntree)
  (modes native byte)
  (modules domain_spawntree)
- (libraries util qcheck)
+ (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule

--- a/src/domainslib/chan_stm_tests.ml
+++ b/src/domainslib/chan_stm_tests.ml
@@ -73,7 +73,7 @@ module ChT = STM.Make(ChConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count,name = 500,"global Domainslib.Chan test" in [
       ChT.agree_test     ~count ~name;
       ChT.agree_test_par ~count ~name;

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -14,9 +14,8 @@
 
 (executable
  (name task_one_dep)
- (modes native byte)
  (modules task_one_dep)
- (libraries util qcheck domainslib)
+ (libraries util qcheck-core qcheck-core.runner domainslib)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
@@ -27,9 +26,8 @@
 
 (executable
  (name task_more_deps)
- (modes native byte)
  (modules task_more_deps)
- (libraries util qcheck domainslib)
+ (libraries util qcheck-core qcheck-core.runner domainslib)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
@@ -40,9 +38,8 @@
 
 (executable
  (name task_parallel)
- (modes native byte)
  (modules task_parallel)
- (libraries util qcheck domainslib))
+ (libraries util qcheck-core qcheck-core.runner domainslib))
 
 (rule
  (alias runtest)
@@ -55,9 +52,8 @@
 
 (executable
  (name chan_stm_tests)
- (modes native byte)
  (modules chan_stm_tests)
- (libraries util qcheck STM domainslib)
+ (libraries util STM domainslib)
  (preprocess (pps ppx_deriving.show)))
 
 (rule

--- a/src/domainslib/task_parallel.ml
+++ b/src/domainslib/task_parallel.ml
@@ -53,7 +53,7 @@ let test_parallel_scan =
        Task.teardown_pool pool;
        a = Array.init array_size (fun i -> i + 1))
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   test_parallel_for;
   test_parallel_for_reduce;
   test_parallel_scan;

--- a/src/ephemeron/dune
+++ b/src/ephemeron/dune
@@ -8,7 +8,7 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
+ (libraries STM)
  (preprocess (pps ppx_deriving.show)))
 
 (rule

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -42,7 +42,7 @@ module ET = Lin_api.Make(EConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
     ET.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Ephemeron test with Domain";
     ET.lin_test     `Thread ~count:250  ~name:"Lin_api Ephemeron test with Thread";
   ]

--- a/src/ephemeron/stm_tests.ml
+++ b/src/ephemeron/stm_tests.ml
@@ -137,7 +137,7 @@ module ETest = STM.Make(EphemeronModel)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [ ETest.agree_test         ~count ~name:"STM Ephemeron test sequential"; (* succeed *)
      ETest.neg_agree_test_par ~count ~name:"STM Ephemeron test parallel";   (* fail *)

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -12,7 +12,7 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
+ (libraries STM)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show)))
 
 (rule
@@ -26,7 +26,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule
@@ -38,7 +38,6 @@
 (executable
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- ;(package multicoretests)
  (libraries multicorecheck.lin))
 
 (rule

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -69,6 +69,6 @@ module HT = Lin.Make(HConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   HT.neg_lin_test     `Domain ~count:1000 ~name:"Lin Hashtbl test with Domain";
 ]

--- a/src/hashtbl/lin_tests_dsl.ml
+++ b/src/hashtbl/lin_tests_dsl.ml
@@ -27,6 +27,6 @@ module HT = Lin_api.Make(HConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   HT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Hashtbl test with Domain";
 ]

--- a/src/hashtbl/stm_tests.ml
+++ b/src/hashtbl/stm_tests.ml
@@ -121,7 +121,7 @@ module HTest = STM.Make(HConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 200 in
    [HTest.agree_test         ~count ~name:"STM Hashtbl test sequential";
     HTest.neg_agree_test_par ~count ~name:"STM Hashtbl test parallel";

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -21,7 +21,7 @@
 (executable
  (name cleanup)
  (modules cleanup)
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (rule

--- a/src/kcas/dune
+++ b/src/kcas/dune
@@ -10,7 +10,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin kcas)
+ (libraries lin kcas)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; disable kcas test for now

--- a/src/kcas/lin_tests.ml
+++ b/src/kcas/lin_tests.ml
@@ -112,7 +112,7 @@ module KW1T = Lin.Make(KW1Conf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   (* Kcas tests *)
   KT.neg_lin_test `Domain ~count:1000 ~name:"Lin Kcas test with Domain";
   KW1T.lin_test   `Domain ~count:1000 ~name:"Lin Kcas.W1 test with Domain";

--- a/src/kcas/lin_tests_dsl.ml
+++ b/src/kcas/lin_tests_dsl.ml
@@ -77,7 +77,7 @@ module KW1T = Lin_api.Make(KW1Conf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
   KT.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Kcas test with Domain";
   KW1T.lin_test   `Domain ~count:1000 ~name:"Lin_api Kcas.W1 test with Domain";
 ]

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -9,8 +9,8 @@
 (executable
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck STM)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (libraries STM)
+ (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
@@ -21,7 +21,7 @@
 (executable
  (name lin_tests)
  (modules lin_tests)
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule
@@ -33,7 +33,6 @@
 (executable
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- ;(package multicoretests)
  (libraries multicorecheck.lin))
 
 ; (rule

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -90,7 +90,7 @@ module LTfromfun = Lin.Make(struct
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 100 in
    [LTlazy.neg_lin_test       `Domain ~count ~name:"Lin Lazy test with Domain";
     LTfromval.lin_test        `Domain ~count ~name:"Lin Lazy test with Domain from_val";

--- a/src/lazy/lin_tests_dsl.ml
+++ b/src/lazy/lin_tests_dsl.ml
@@ -67,7 +67,7 @@ module LTfromfun = Lin_api.Make(LTfromfunAPI)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 100 in
    [LTlazy.neg_lin_test    `Domain ~count ~name:"Lin_api Lazy test with Domain";
     LTfromval.lin_test     `Domain ~count ~name:"Lin_api Lazy test with Domain from_val";

--- a/src/lazy/stm_tests.ml
+++ b/src/lazy/stm_tests.ml
@@ -115,7 +115,7 @@ module LTfromfun = STM.Make(struct
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 200 in
    [LTlazy.agree_test        ~count ~name:"STM Lazy test sequential";
     LTfromval.agree_test     ~count ~name:"STM Lazy test sequential from_val";

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -11,7 +11,7 @@
 (executable
  (name ws_deque_test)
  (modules ws_deque_test)
- (libraries qcheck STM lockfree)
+ (libraries STM lockfree)
  (preprocess (pps ppx_deriving.show)))
 
 (rule

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -119,7 +119,7 @@ let agree_test_par_negative ~count ~name = WSDT.neg_agree_test_par ~count ~name
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in [
     WSDT.agree_test         ~count ~name:"ws_deque test";
     agree_test_par          ~count ~name:"parallel ws_deque test";

--- a/src/neg_tests/conclist_stm_tests.ml
+++ b/src/neg_tests/conclist_stm_tests.ml
@@ -54,7 +54,7 @@ module CLT_int64 = STM.Make(CLConf(Int64))
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [CLT_int.agree_test       ~count ~name:"STM int CList test sequential";
     CLT_int64.agree_test     ~count ~name:"STM int64 CList test sequential";

--- a/src/neg_tests/domain_lin_tests.ml
+++ b/src/neg_tests/domain_lin_tests.ml
@@ -5,7 +5,7 @@ open Lin_tests_common
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.neg_lin_test    `Domain ~count ~name:"Lin ref int test with Domain";
     RT_int64.neg_lin_test  `Domain ~count ~name:"Lin ref int64 test with Domain";

--- a/src/neg_tests/domain_lin_tests_dsl.ml
+++ b/src/neg_tests/domain_lin_tests_dsl.ml
@@ -5,7 +5,7 @@ open Lin_tests_common_dsl
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 10000 in
    [RT_int.neg_lin_test    `Domain ~count ~name:"Lin_api ref int test with Domain";
     RT_int64.neg_lin_test  `Domain ~count ~name:"Lin_api ref int64 test with Domain";

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -14,8 +14,8 @@
 (executable
  (name ref_stm_tests)
  (modules ref_stm_tests)
- (libraries qcheck STM)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (libraries STM)
+ (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
@@ -30,8 +30,8 @@
 (executable
  (name conclist_stm_tests)
  (modules conclist_stm_tests)
- (libraries CList qcheck STM)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (libraries CList STM)
+ (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
@@ -46,12 +46,12 @@
 (library
  (name lin_tests_common_dsl)
  (modules lin_tests_common_dsl)
- (libraries qcheck lin CList))
+ (libraries lin CList))
 
 (library
  (name lin_tests_common)
  (modules lin_tests_common)
- (libraries qcheck lin CList)
+ (libraries lin CList)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 (executables

--- a/src/neg_tests/effect_lin_tests.ml
+++ b/src/neg_tests/effect_lin_tests.ml
@@ -59,7 +59,7 @@ module CLT_int64' = Lin.Make(CLConf_int64')
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
       RT_int.lin_test     `Effect ~count ~name:"Lin ref int test with Effect";

--- a/src/neg_tests/effect_lin_tests_dsl.ml
+++ b/src/neg_tests/effect_lin_tests_dsl.ml
@@ -78,7 +78,7 @@ module CLT_int64' = Lin_api.Make(CList_spec_int64')
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
       RT_int.lin_test     `Effect ~count ~name:"Lin_api ref int test with Effect";

--- a/src/neg_tests/ref_stm_tests.ml
+++ b/src/neg_tests/ref_stm_tests.ml
@@ -145,7 +145,7 @@ module RT_int64_GC = STM.Make(RConf_int64_GC)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.agree_test            ~count ~name:"STM int ref test sequential";
     RT_int.neg_agree_test_par    ~count ~name:"STM int ref test parallel";

--- a/src/neg_tests/thread_lin_tests.ml
+++ b/src/neg_tests/thread_lin_tests.ml
@@ -5,7 +5,7 @@ open Lin_tests_common
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.lin_test       `Thread ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
     RT_int64.neg_lin_test `Thread ~count ~name:"Lin ref int64 test with Thread";

--- a/src/neg_tests/thread_lin_tests_dsl.ml
+++ b/src/neg_tests/thread_lin_tests_dsl.ml
@@ -5,7 +5,7 @@ open Lin_tests_common_dsl
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.lin_test       `Thread ~count ~name:"Lin_api ref int test with Thread";
     RT_int64.neg_lin_test `Thread ~count ~name:"Lin_api ref int64 test with Thread";

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -10,7 +10,7 @@
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
  (flags (:standard -w -27))
- (libraries qcheck lin))
+ (libraries lin))
 
 (rule
  (alias runtest)
@@ -22,7 +22,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -110,7 +110,7 @@ module QT  = Lin.Make(QConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
     QMT.lin_test    `Domain ~count:1000 ~name:"Lin Queue test with Domain and mutex";
     QMT.lin_test    `Thread ~count:1000 ~name:"Lin Queue test with Thread and mutex";
     QT.neg_lin_test `Domain ~count:1000 ~name:"Lin Queue test with Domain without mutex";

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -20,7 +20,7 @@ end
 module Lin_queue = Lin_api.Make(Queue_spec)
 
 let () =
-  QCheck_runner.run_tests_main [
+  QCheck_base_runner.run_tests_main [
     Lin_queue.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Queue test with Domain";
     Lin_queue.lin_test     `Thread ~count:250  ~name:"Lin_api Queue test with Thread";
   ]

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -10,7 +10,7 @@
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
  (flags (:standard -w -27))
- (libraries qcheck lin))
+ (libraries lin))
 
 (rule
  (alias runtest)
@@ -22,7 +22,7 @@
  (name lin_tests)
  (modules lin_tests)
  (flags (:standard -w -27))
- (libraries qcheck lin)
+ (libraries lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 ; (rule

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -110,7 +110,7 @@ module SMT = Lin.Make(SMutexConf)
 ;;
 Util.set_ci_printing ()
 ;;
-QCheck_runner.run_tests_main [
+QCheck_base_runner.run_tests_main [
     SMT.lin_test    `Domain ~count:1000 ~name:"Lin Stack test with Domain and mutex";
     SMT.lin_test    `Thread ~count:1000 ~name:"Lin Stack test with Thread and mutex";
     ST.neg_lin_test `Domain ~count:1000 ~name:"Lin Stack test with Domain without mutex";

--- a/src/stack/lin_tests_dsl.ml
+++ b/src/stack/lin_tests_dsl.ml
@@ -20,7 +20,7 @@ module Stack_spec : Lin_api.ApiSpec = struct
 module Lin_stack = Lin_api.Make(Stack_spec)
 
 let () =
-  QCheck_runner.run_tests_main [
+  QCheck_base_runner.run_tests_main [
       Lin_stack.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Stack test with Domain";
       Lin_stack.lin_test     `Thread ~count:250  ~name:"Lin_api Stack test with Thread";
     ]

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -11,10 +11,9 @@
 
 (executable
  (name thread_joingraph)
- (modes native byte)
  (modules thread_joingraph)
- (libraries threads util qcheck)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (libraries threads qcheck-core util)
+ (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
@@ -24,10 +23,9 @@
 
 (executable
  (name thread_createtree)
- (modes native byte)
  (modules thread_createtree)
- (libraries threads qcheck util)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (libraries threads qcheck-core util)
+ (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
This PR reduces the QCheck dependencies of both opam packages from `"qcheck"` to `"qcheck-core"`.

To do so, it reduces the dependencies in 
- the opam files
- `STM`, `Lin`, and `Lin_api`
- the `src` tests
- the `doc` examples
- the frontpage README