### PR TITLE
Shorten Lin_api.val_with_freq to Lin_api.val_freq

### DIFF
--- a/lib/lin_api.ml
+++ b/lib/lin_api.ml
@@ -132,7 +132,7 @@ type 's api = (int * 's elem) list
 let val_ name value fntyp =
   (1, Elem (name, fntyp, value))
 
-let val_with_freq freq name value fntyp =
+let val_freq freq name value fntyp =
   (freq, Elem (name, fntyp, value))
 
 module type ApiSpec = sig

--- a/lib/lin_api.mli
+++ b/lib/lin_api.mli
@@ -83,7 +83,7 @@ type _ elem = private
 type 's api = (int * 's elem) list
 
 val val_ : string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
-val val_with_freq : int -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
+val val_freq : int -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
 
 module type ApiSpec =
   sig


### PR DESCRIPTION
This PR shortens `Lin_api.val_with_freq` to `Lin_api.val_freq` to make signature descriptions with a skewed distribution a little less wordy:
```ocaml
  let api =
    [ val_ "Hashtbl.clear"    Hashtbl.clear    (t @-> returning unit);
      val_ "Hashtbl.add"      Hashtbl.add      (t @-> char @-> int @-> returning unit);
      val_freq 3 "Hashtbl.remove"   Hashtbl.remove   (t @-> char @-> returning unit);
     ... ]
```
compared to
```ocaml
  let api =
    [ val_ "Hashtbl.clear"    Hashtbl.clear    (t @-> returning unit);
      val_ "Hashtbl.add"      Hashtbl.add      (t @-> char @-> int @-> returning unit);
      val_with_freq 3 "Hashtbl.remove"   Hashtbl.remove   (t @-> char @-> returning unit);
     ... ]
```


