### PR TITLE
Clarify lockfree/ws_deque definitions

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -125,7 +125,7 @@ module Make(Spec : StmSpec)
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * res) list
     val check_obs : (Spec.cmd * res) list -> (Spec.cmd * res) list -> (Spec.cmd * res) list -> Spec.state -> bool
     val gen_cmds_size : Spec.state -> int Gen.t -> Spec.cmd list Gen.t
-  (*val shrink_triple : ...*)
+    val shrink_triple : (Spec.cmd list * Spec.cmd list * Spec.cmd list) Shrink.t
     val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     val agree_prop_par         : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
     val agree_test_par         : count:int -> name:string -> Test.t


### PR DESCRIPTION
This PR fixes #106 

Besides adding comments to clarify how the definitions differ from those in `lib/STM.ml` it also
- adds `shrink_triple` to the public interface and
- reuses it to minimize the differences