### PR TITLE
Add tests for domains and threads interactions

### DIFF
--- a/src/threadomain/dune
+++ b/src/threadomain/dune
@@ -1,0 +1,20 @@
+;; Tests of the interactions between Threads and Domains
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps threadomain.exe))
+
+(executable
+ (name threadomain)
+ (modes native byte)
+ (modules threadomain)
+ (libraries util qcheck-core threads)
+ (preprocess (pps ppx_deriving.show)))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps threadomain.exe)
+ (action (run ./%{deps} --no-colors --verbose)))

--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -1,0 +1,139 @@
+open QCheck
+
+(* We mix domains and threads. We use the name _node_ for either a
+   domain or a thread *)
+
+(* The global number of nodes that will be spawn *)
+let size = 2 * Domain.recommended_domain_count
+
+let swap arr i j =
+  let x = arr.(i) in
+  arr.(i) <- arr.(j) ;
+  arr.(j) <- x
+
+(** Generate a permutation of [0..size-1] *)
+let permutation s =
+  let arr = Array.init size (fun x -> x) in
+  for i = size - 1 downto 1 do
+    swap arr i (Gen.int_bound i s)
+  done ;
+  arr
+
+(** Generate a tree of size nodes
+ The tree is represented as an array [a] of integers, [a.(i)] being
+ the parent of node [i]. Node [0] is the root of the tree.
+ *)
+let tree s =
+  let parent i =
+    if i == 0
+    then -1
+    else Gen.int_bound (i-1) s
+  in
+  Array.init size parent
+
+(** A test of spawn and join
+
+    [spawn_tree] describes which domain/thread should spawn which other
+    domains/threads
+    [join_permutation] maps nodes to their position in the [join_tree]
+    [join_tree] describes which domain/thread should wait on which
+    other domains/threads
+    [domain_or] describes whether a given node is a domain (true) or a
+    thread (false)
+
+    All those arrays should be of the same length, maybe an array of
+    tuples would be a better choice, but make harder to read
+*)
+type spawn_join = {
+  spawn_tree:       int array;
+  join_permutation: int array;
+  join_tree:        int array;
+  domain_or:        bool array
+} [@@deriving show { with_path = false }]
+
+(* Ensure that any domain is higher up in the join tree than all its
+   threads, so that we cannot have a thread waiting on its domain even
+   indirectly *)
+let fix_permutation sj =
+  let rec dom_of_thd i =
+    let candidate = sj.spawn_tree.(i) in
+    if candidate = -1 || sj.domain_or.(candidate)
+    then candidate
+    else dom_of_thd candidate
+  in
+  for i = 0 to size-1 do
+    if not sj.domain_or.(i) then
+      let i' = sj.join_permutation.(i) in
+      let d = dom_of_thd i in
+      let d' = if d = -1 then d else sj.join_permutation.(d) in
+      if d' > i' then swap sj.join_permutation i d
+  done ;
+  sj
+
+let build_spawn_join spawn_tree join_permutation join_tree domain_or =
+  fix_permutation { spawn_tree; join_permutation; join_tree; domain_or }
+
+let gen_spawn_join =
+  let open Gen in
+  build_spawn_join <$> tree <*> permutation <*> tree <*> array_size (pure size) bool
+
+type handle =
+  | NoHdl
+  | DomainHdl of unit Domain.t
+  | ThreadHdl of Thread.t
+
+(* All the node handles.
+   Since they’ll be used to join, they are stored in join_permutation
+   order *)
+type handles = {
+  handles: handle array;
+  available: Semaphore.Binary.t array
+}
+
+let join_one hdls i =
+  Semaphore.Binary.acquire hdls.available.(i) ;
+  ( match hdls.handles.(i) with
+    | NoHdl -> failwith "Semaphore acquired but no handle to join"
+    | DomainHdl h -> ( Domain.join h ;
+                       hdls.handles.(i) <- NoHdl )
+    | ThreadHdl h -> ( Thread.join h ;
+                       hdls.handles.(i) <- NoHdl ) )
+
+let rec spawn_one sj hdls i =
+  hdls.handles.(sj.join_permutation.(i)) <-
+    if sj.domain_or.(i)
+    then DomainHdl (Domain.spawn (run_node sj hdls i))
+    else ThreadHdl (Thread.create (run_node sj hdls i) ()) ;
+  Semaphore.Binary.release hdls.available.(sj.join_permutation.(i))
+
+and run_node sj hdls i () =
+  (* spawn nodes *)
+  for j = i+1 to size-1 do
+    if sj.spawn_tree.(j) == i
+    then spawn_one sj hdls j
+  done ;
+  (* join nodes *)
+  let i' = sj.join_permutation.(i) in
+  for j = i'+1 to size-1 do
+    if sj.join_tree.(j) == i'
+    then join_one hdls j
+  done
+
+let run_all_nodes sj =
+  let hdls = { handles = Array.make size NoHdl;
+               available = Array.init size (fun _ -> Semaphore.Binary.make false) } in
+  spawn_one sj hdls 0;
+  join_one hdls 0;
+  (* all the nodes should have been joined now *)
+  Array.for_all (fun h -> h = NoHdl) hdls.handles
+
+let main_test = Test.make ~name:"Mash up of threads and domains"
+                          ~count:1000
+                          (make ~print:show_spawn_join gen_spawn_join)
+                          (Util.fork_prop_with_timeout 1 run_all_nodes)
+
+let _ =
+  Util.set_ci_printing () ;
+  QCheck_base_runner.run_tests_main [
+    main_test
+  ]

--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -3,18 +3,15 @@ open QCheck
 (* We mix domains and threads. We use the name _node_ for either a
    domain or a thread *)
 
-(* The global number of nodes that will be spawn *)
-let size = 5 * Domain.recommended_domain_count
-
 let swap arr i j =
   let x = arr.(i) in
   arr.(i) <- arr.(j) ;
   arr.(j) <- x
 
 (** Generate a permutation of [0..size-1] *)
-let permutation s =
-  let arr = Array.init size (fun x -> x) in
-  for i = size - 1 downto 1 do
+let permutation sz s =
+  let arr = Array.init sz (fun x -> x) in
+  for i = sz - 1 downto 1 do
     swap arr i (Gen.int_bound i s)
   done ;
   arr
@@ -23,13 +20,13 @@ let permutation s =
  The tree is represented as an array [a] of integers, [a.(i)] being
  the parent of node [i]. Node [0] is the root of the tree.
  *)
-let tree s =
+let tree sz s =
   let parent i =
     if i == 0
     then -1
     else Gen.int_bound (i-1) s
   in
-  Array.init size parent
+  Array.init sz parent
 
 type worktype = Burn | Tak of int
   [@@deriving show { with_path = false }]
@@ -58,14 +55,14 @@ type spawn_join = {
 (* Ensure that any domain is higher up in the join tree than all its
    threads, so that we cannot have a thread waiting on its domain even
    indirectly *)
-let fix_permutation sj =
+let fix_permutation sz sj =
   let rec dom_of_thd i =
     let candidate = sj.spawn_tree.(i) in
     if candidate = -1 || sj.domain_or.(candidate)
     then candidate
     else dom_of_thd candidate
   in
-  for i = 0 to size-1 do
+  for i = 0 to sz-1 do
     if not sj.domain_or.(i) then
       let i' = sj.join_permutation.(i) in
       let d = dom_of_thd i in
@@ -74,19 +71,19 @@ let fix_permutation sj =
   done ;
   sj
 
-let build_spawn_join spawn_tree join_permutation join_tree domain_or workload =
-  fix_permutation { spawn_tree; join_permutation; join_tree; domain_or; workload }
+let build_spawn_join sz spawn_tree join_permutation join_tree domain_or workload =
+  fix_permutation sz { spawn_tree; join_permutation; join_tree; domain_or; workload }
 
 let worktype =
   let open Gen in
   oneof [pure Burn; map (fun i -> Tak i) (int_bound 200)]
 
-let gen_spawn_join =
+let gen_spawn_join sz =
   let open Gen in
-  build_spawn_join
-    <$> tree <*> permutation <*> tree
-    <*> array_size (pure size) (frequencyl [(1, true); (4, false)])
-    <*> array_size (pure size) worktype
+  build_spawn_join sz
+    <$> tree sz <*> permutation sz <*> tree sz
+    <*> array_size (pure sz) (frequencyl [(1, true); (4, false)])
+    <*> array_size (pure sz) worktype
 
 type handle =
   | NoHdl
@@ -139,8 +136,9 @@ let rec spawn_one sj hdls i =
   Semaphore.Binary.release hdls.available.(sj.join_permutation.(i))
 
 and run_node sj hdls i () =
+  let sz = Array.length sj.spawn_tree in
   (* spawn nodes *)
-  for j = i+1 to size-1 do
+  for j = i+1 to sz-1 do
     if sj.spawn_tree.(j) == i
     then spawn_one sj hdls j
   done ;
@@ -148,23 +146,24 @@ and run_node sj hdls i () =
   work sj.workload.(i) ;
   (* join nodes *)
   let i' = sj.join_permutation.(i) in
-  for j = i'+1 to size-1 do
+  for j = i'+1 to sz-1 do
     if sj.join_tree.(j) == i'
     then join_one hdls j
   done
 
 let run_all_nodes sj =
-  let hdls = { handles = Array.make size NoHdl;
-               available = Array.init size (fun _ -> Semaphore.Binary.make false) } in
+  let sz = Array.length sj.spawn_tree in
+  let hdls = { handles = Array.make sz NoHdl;
+               available = Array.init sz (fun _ -> Semaphore.Binary.make false) } in
   spawn_one sj hdls 0;
   join_one hdls 0;
   (* all the nodes should have been joined now *)
   Array.for_all (fun h -> h = NoHdl) hdls.handles
-   && Atomic.get global = size
+   && Atomic.get global = sz
 
 let main_test = Test.make ~name:"Mash up of threads and domains"
                           ~count:1000
-                          (make ~print:show_spawn_join gen_spawn_join)
+                          (make ~print:show_spawn_join (Gen.sized_size (Gen.int_range 2 100) gen_spawn_join))
                           (Util.fork_prop_with_timeout 1 run_all_nodes)
 
 let _ =

--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -4,7 +4,7 @@ open QCheck
    domain or a thread *)
 
 (* The global number of nodes that will be spawn *)
-let size = 2 * Domain.recommended_domain_count
+let size = 5 * Domain.recommended_domain_count
 
 let swap arr i j =
   let x = arr.(i) in
@@ -85,7 +85,7 @@ let gen_spawn_join =
   let open Gen in
   build_spawn_join
     <$> tree <*> permutation <*> tree
-    <*> array_size (pure size) bool
+    <*> array_size (pure size) (frequencyl [(1, true); (4, false)])
     <*> array_size (pure size) worktype
 
 type handle =

--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -80,7 +80,7 @@ let gen_spawn_join sz =
   let open Gen in
   build_spawn_join sz
     <$> tree sz <*> permutation sz <*> tree sz
-    <*> array_size (pure sz) (frequencyl [(1, true); (4, false)])
+    <*> array_size (pure sz) (frequencyl [(4, false); (1, true)])
     <*> array_size (pure sz) worktype
 
 type handle =


### PR DESCRIPTION
These tests generate random trees of spawning nodes (either a domain or a thread) and then joining them in another random pattern

These tests only come with generators, not shrinkers, at the moment. It would be interesting to add some shrinkers if we run into failing examples.