### PR TITLE
give each parts of the program a specific cmd generator

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -125,7 +125,7 @@ module Make(Spec : StmSpec)
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * res) list
     val check_obs : (Spec.cmd * res) list -> (Spec.cmd * res) list -> (Spec.cmd * res) list -> Spec.state -> bool
     (* val gen_cmds_size : Spec.state -> int Gen.t -> Spec.cmd list Gen.t *)
-    val shrink_triple : (Spec.cmd list * Spec.cmd list * Spec.cmd list) Shrink.t
+    (* val shrink_triple : (Spec.cmd list * Spec.cmd list * Spec.cmd list) Shrink.t *)
     val arb_cmds_par_ : (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     val agree_prop_par         : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
@@ -294,33 +294,33 @@ struct
   let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
 
   (* Shrinks a single cmd, starting in the given state *)
-  let shrink_cmd cmd state =
-    Option.value Spec.(arb_cmd state).shrink ~default:Shrink.nil @@ cmd
+  let shrink_cmd arb cmd state =
+    Option.value (arb state).shrink ~default:Shrink.nil @@ cmd
 
   (* Shrinks cmd lists, starting in the given state *)
-  let rec shrink_cmd_list cs state = match cs with
+  let rec shrink_cmd_list arb cs state = match cs with
     | [] -> Iter.empty
     | c::cs ->
         if Spec.precond c state
         then
           Iter.(
-            map (fun c -> c::cs) (shrink_cmd c state)
+            map (fun c -> c::cs) (shrink_cmd arb c state)
             <+>
-            map (fun cs -> c::cs) (shrink_cmd_list cs Spec.(next_state c state))
+            map (fun cs -> c::cs) (shrink_cmd_list arb cs Spec.(next_state c state))
           )
         else Iter.empty
 
   (* Shrinks cmd elements in triples *)
-  let shrink_triple_elems (seq,p1,p2) =
+  let shrink_triple_elems arb0 arb1 arb2 (seq,p1,p2) =
     let shrink_prefix cs state =
-      Iter.map (fun cs -> (cs,p1,p2)) (shrink_cmd_list cs state)
+      Iter.map (fun cs -> (cs,p1,p2)) (shrink_cmd_list arb0 cs state)
     in
     let rec shrink_par_suffix cs state = match cs with
       | [] ->
           (* try only one option: p1s or p2s first - both valid interleavings *)
-          Iter.(map (fun p1 -> (seq,p1,p2)) (shrink_cmd_list p1 state)
+          Iter.(map (fun p1 -> (seq,p1,p2)) (shrink_cmd_list arb1 p1 state)
                 <+>
-                map (fun p2 -> (seq,p1,p2)) (shrink_cmd_list p2 state))
+                map (fun p2 -> (seq,p1,p2)) (shrink_cmd_list arb2 p2 state))
       | c::cs ->
           (* walk seq prefix (again) to advance state *)
           if Spec.precond c state
@@ -335,7 +335,7 @@ struct
               shrink_par_suffix seq Spec.init_state)
 
   (* General shrinker of cmd triples *)
-  let shrink_triple =
+  let shrink_triple arb0 arb1 arb2 =
     let open Iter in
     Shrink.filter
       (fun (seq,p1,p2) -> all_interleavings_ok seq p1 p2 Spec.init_state)
@@ -354,10 +354,11 @@ struct
         (map (fun p2' -> (seq,p1,p2')) (Shrink.list_spine p2))
         <+>
         (* Secondly reduce the cmd data of individual list elements *)
-        (shrink_triple_elems triple))
+        (shrink_triple_elems arb0 arb1 arb2 triple))
 
   let arb_cmds_par_ arb0 arb1 arb2 seq_len par_len =
     let seq_pref_gen = gen_cmds_size arb0 Spec.init_state (Gen.int_bound seq_len) in
+    let shrink_triple = shrink_triple arb0 arb1 arb2 in
     let gen_triple =
       Gen.(seq_pref_gen >>= fun seq_pref ->
            int_range 2 (2*par_len) >>= fun dbl_plen ->

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -113,7 +113,6 @@ end
 module Make(Spec : StmSpec)
   : sig
     val cmds_ok : Spec.state -> Spec.cmd list -> bool
-    (* val gen_cmds : Spec.state -> int -> Spec.cmd list Gen.t *)
     val arb_cmds : Spec.state -> Spec.cmd list arbitrary
     val consistency_test : count:int -> name:string -> Test.t
     val interp_agree : Spec.state -> Spec.sut -> Spec.cmd list -> bool
@@ -124,9 +123,7 @@ module Make(Spec : StmSpec)
   (*val check_and_next : (Spec.cmd * res) -> Spec.state -> bool * Spec.state*)
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * res) list
     val check_obs : (Spec.cmd * res) list -> (Spec.cmd * res) list -> (Spec.cmd * res) list -> Spec.state -> bool
-    (* val gen_cmds_size : Spec.state -> int Gen.t -> Spec.cmd list Gen.t *)
-    (* val shrink_triple : (Spec.cmd list * Spec.cmd list * Spec.cmd list) Shrink.t *)
-    val arb_cmds_par_ : (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
+    val arb_triple : (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     val agree_prop_par         : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
     val agree_test_par         : count:int -> name:string -> Test.t
@@ -356,7 +353,7 @@ struct
         (* Secondly reduce the cmd data of individual list elements *)
         (shrink_triple_elems arb0 arb1 arb2 triple))
 
-  let arb_cmds_par_ arb0 arb1 arb2 seq_len par_len =
+  let arb_triple arb0 arb1 arb2 seq_len par_len =
     let seq_pref_gen = gen_cmds_size arb0 Spec.init_state (Gen.int_bound seq_len) in
     let shrink_triple = shrink_triple arb0 arb1 arb2 in
     let gen_triple =
@@ -369,7 +366,7 @@ struct
            triple (return seq_pref) par_gen1 par_gen2) in
     make ~print:(print_triple_vertical Spec.show_cmd) ~shrink:shrink_triple gen_triple
 
-  let arb_cmds_par = arb_cmds_par_ Spec.arb_cmd Spec.arb_cmd Spec.arb_cmd
+  let arb_cmds_par = arb_triple Spec.arb_cmd Spec.arb_cmd Spec.arb_cmd
 
   (* Parallel agreement property based on [Domain] *)
   let agree_prop_par (seq_pref,cmds1,cmds2) =

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -84,23 +84,15 @@ let agree_prop_par =
             List.map snd own_obs,
             List.map snd stealer_obs))
 
-(* [arb_triple] differs in what each triple component generates:
+(* [arb_cmds_arb] differs in what each triple component generates:
    "Owner domain" cmds can't be [Steal], "stealer domain" cmds can only be [Steal]. *)
-let arb_triple =
-  let seq_len,par_len = 20,15 in
-  let seq_pref_gen = WSDT.gen_cmds_size WSDConf.init_state (Gen.int_bound seq_len) in
-  let triple_gen = Gen.(seq_pref_gen >>= fun seq_pref ->
-                        let spawn_state = List.fold_left (fun st c -> WSDConf.next_state c st) WSDConf.init_state seq_pref in
-                        let owner_gen = WSDT.gen_cmds_size spawn_state (Gen.int_bound par_len) in
-                        let stealer_gen = list_size (int_bound par_len) (WSDConf.stealer_cmd spawn_state).gen in (* Note: stealer_cmd *)
-                        map2 (fun owner stealer -> (seq_pref,owner,stealer)) owner_gen stealer_gen) in
-  make ~print:(Util.print_triple_vertical ~center_prefix:false WSDConf.show_cmd) ~shrink: WSDT.shrink_triple triple_gen
+let arb_cmds_par = WSDT.arb_cmds_par_ WSDConf.arb_cmd WSDConf.arb_cmd WSDConf.stealer_cmd 20 15
 
 (* A parallel agreement test - w/repeat and retries combined *)
 let agree_test_par ~count ~name =
   let rep_count = 50 in
   Test.make ~retries:10 ~count ~name
-    arb_triple (STM.repeat rep_count agree_prop_par) (* 50 times each, then 50 * 10 times when shrinking *)
+    arb_cmds_par (STM.repeat rep_count agree_prop_par) (* 50 times each, then 50 * 10 times when shrinking *)
 
 (* Note: since this can generate, e.g., [Pop] commands/actions in the "stealer domain",
    we are violating the spec. - and the deque will not behave as expected, hence a negative test *)

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -86,7 +86,7 @@ let agree_prop_par =
 
 (* [arb_cmds_arb] differs in what each triple component generates:
    "Owner domain" cmds can't be [Steal], "stealer domain" cmds can only be [Steal]. *)
-let arb_cmds_par = WSDT.arb_cmds_par_ WSDConf.arb_cmd WSDConf.arb_cmd WSDConf.stealer_cmd 20 15
+let arb_cmds_par = WSDT.arb_triple WSDConf.arb_cmd WSDConf.arb_cmd WSDConf.stealer_cmd 20 15
 
 (* A parallel agreement test - w/repeat and retries combined *)
 let agree_test_par ~count ~name =


### PR DESCRIPTION
This is an attempt to solve issue #36 with no modification of the existing tests (except for `lockfree/ws_deque_test.ml` which benefits from the change)

`STM.Make` exposes a new function `arb_cmds_par_` which is parametirized by three `Spec.cmd QCheck.arbitrary` (granted, the name is far from great).

I have also updated `arb_triple` to `arb_cmds_par` in `lockfree/ws_deque_test.ml` according to the name in `STM`.
