### PR TITLE
Add STM tests for Semaphore.Counting

### DIFF
--- a/src/semaphore/dune
+++ b/src/semaphore/dune
@@ -1,0 +1,19 @@
+;; Tests of Semaphore.Counting
+
+;; this prevents the tests from running on a default build
+(alias
+ (name default)
+ (package multicoretests)
+ (deps stm_tests.exe))
+
+(executable
+ (name stm_tests)
+ (modules stm_tests)
+ (libraries STM)
+ (preprocess (pps ppx_deriving.show)))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (deps stm_tests.exe)
+ (action (run ./%{deps} --no-colors --verbose)))

--- a/src/semaphore/stm_tests.ml
+++ b/src/semaphore/stm_tests.ml
@@ -1,0 +1,73 @@
+open QCheck
+open STM
+
+(** parallel STM tests of Semaphore.Counting *)
+
+(* Semaphore API these tests will exercise
+
+  val make : int -> t
+  val release : t -> unit
+  val acquire : t -> unit
+  val try_acquire : t -> bool
+  val get_value : t -> int
+
+*)
+
+module SC = Semaphore.Counting
+
+module SCConf =
+  struct
+    type sut = SC.t
+    type state = int
+    type cmd =
+      | Release
+      | Acquire
+      | TryAcquire
+      | GetValue
+      [@@deriving show { with_path = false }]
+
+    let init_state = 2
+
+    let init_sut () = SC.make init_state
+    let cleanup _ = ()
+
+    let arb_cmd s =
+      let cmds = [ Release; TryAcquire; GetValue ] in
+      let cmds = if s > 0 then Acquire :: cmds else cmds in
+      QCheck.make ~print:show_cmd (Gen.oneofl cmds)
+
+    let next_state c s = match c with
+      | Release -> s+1
+      | Acquire -> s-1
+      | TryAcquire -> if s > 0 then s-1 else s
+      | GetValue -> s
+
+    let run c sem =
+      match c with
+      | Release    -> Res (unit, SC.release sem)
+      | Acquire    -> Res (unit, SC.acquire sem)
+      | TryAcquire -> Res (bool, SC.try_acquire sem)
+      | GetValue   -> Res (int,  SC.get_value sem)
+
+    let precond c s =
+      match c with
+      | Acquire -> s > 0
+      | _       -> true
+    let postcond c s res =
+      match c,res with
+      | Release,    Res ((Unit,_), _)
+      | Acquire,    Res ((Unit,_), _) -> true
+      | TryAcquire, Res ((Bool,_),r)  -> r = (s > 0)
+      | GetValue,   Res ((Int,_),r)   -> r = s
+      | _                             -> false
+  end
+
+module SCTest = STM.Make(SCConf)
+
+let _ =
+  Util.set_ci_printing () ;
+  QCheck_base_runner.run_tests_main
+    (let count = 200 in
+     [SCTest.agree_test     ~count ~name:"STM Semaphore.Counting test sequential";
+      SCTest.agree_test_par ~count ~name:"STM Semaphore.Counting test parallel";
+     ])


### PR DESCRIPTION
I wonder whether using this is making proper use of the `precond`. Without this, the tests will deadlock, as can be expected, but this prevents exercising the deadlock behaviour.