### PR TITLE
Remove timeout in the domains+threads tests

### DIFF
--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -150,6 +150,7 @@ and run_node sj hdls i () =
   done
 
 let run_all_nodes sj =
+  Atomic.set global 0 ;
   let sz = Array.length sj.spawn_tree in
   let hdls = { handles = Array.make sz NoHdl;
                available = Array.init sz (fun _ -> Semaphore.Binary.make false) } in
@@ -163,7 +164,9 @@ let main_test = Test.make ~name:"Mash up of threads and domains"
                           ~count:1000
                           ~print:show_spawn_join
                           (Gen.sized_size (Gen.int_range 2 100) gen_spawn_join)
-                          (Util.fork_prop_with_timeout 1 run_all_nodes)
+                          run_all_nodes
+                          (* to debug deadlocks: *)
+                          (* (Util.fork_prop_with_timeout 1 run_all_nodes) *)
 
 let _ =
   Util.set_ci_printing () ;


### PR DESCRIPTION
Now that the generated join patterns cannot (should not) create deadlocks, remove the timeout so that the property won’t fail just because it ran out of time