### PR TITLE
Use the Timeout exception in fork_prop_with_timeout

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -30,6 +30,7 @@ let fork_prop_with_timeout sec p x =
     let _childid, retcode = Unix.wait () in
     (match retcode with
      | WEXITED code -> (0=code)
+     | WSIGNALED s when s = Sys.sigalrm -> raise Timeout
      | WSIGNALED _
      | WSTOPPED _  -> false)
 


### PR DESCRIPTION
Adopt in fork_prop_with_timeout the same behaviour as in prop_timeout, namely raising a Timeout exception when the child did end on a SIGALRM signal