### PR TITLE
CI: Set up a 3-hour timeout on native runs

### DIFF
--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 180
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 180
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: macos-latest
 
+    timeout-minutes: 180
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: macos-latest
 
+    timeout-minutes: 180
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Tests on native builds should not run for more than 2 hours so a 3-hour timeout will abort failing tests sooner.
Tests on bytecode builds run often above 4 hours so keeping the default 6-hour timeout makes sense