### PR TITLE
CI speedup

### DIFF
--- a/.github/bin/apt-get
+++ b/.github/bin/apt-get
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Dummy `apt-get`, to skip some useless installations
+echo Dummy: apt-get "$@"
+exit 0

--- a/.github/bin/brew
+++ b/.github/bin/brew
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Dummy `brew`, to skip some useless installations
+echo Dummy: brew "$@"
+exit 0

--- a/.github/bin/sudo
+++ b/.github/bin/sudo
@@ -1,5 +1,11 @@
 #!/bin/sh
 
 # Dummy `sudo`, to skip some useless invocations to apt-get
-echo Dummy: sudo "$@"
+if [ "$1" = "apt-get" -a "$2" = "install" ]; then
+  echo Dummy sudo: installing bubblewrap only instead of running: "$@"
+  /usr/bin/sudo apt-get install bubblewrap
+else
+  echo Dummy: sudo "$@"
+fi
+
 exit 0

--- a/.github/bin/sudo
+++ b/.github/bin/sudo
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Dummy `sudo`, to skip some useless invocations to apt-get
+echo Dummy: sudo "$@"
+exit 0

--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -23,6 +23,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0+trunk bytecode only
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0~alpha1 bytecode only
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -23,6 +23,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -32,4 +32,4 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet
+      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -28,6 +28,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0+trunk
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -25,6 +25,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0~alpha1
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -25,6 +25,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -28,6 +28,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0+trunk
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -28,6 +28,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use CI $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
       - name: Use OCaml 5.0.0~alpha1
         uses: ocaml/setup-ocaml@v2
         with:


### PR DESCRIPTION
Set up two simple ways to speed up the initialization part of CI builds: activate `dune` cache and bypass useless `brew` installations on macos.