### PR TITLE
Reduce threadomain count

### DIFF
--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -161,7 +161,7 @@ let run_all_nodes sj =
    && Atomic.get global = sz
 
 let main_test = Test.make ~name:"Mash up of threads and domains"
-                          ~count:1000
+                          ~count:500
                           ~print:show_spawn_join
                           (Gen.sized_size (Gen.int_range 2 100) gen_spawn_join)
                           run_all_nodes


### PR DESCRIPTION
The Thread-Domain mash up test is dominant in the CI. For example, it takes
- 364.2s in this Linux native run: https://github.com/jmid/multicoretests/actions/runs/3245244865/jobs/5322519932
- 1855.5s in this bytecode run: https://github.com/jmid/multicoretests/actions/runs/3245244809/jobs/5322519748

This PR reduces the count from 1000 to 500 to save CI time.