### PR TITLE
Reduce frequencies of operations creating Bigarrays

### DIFF
--- a/src/bigarray/lin_tests_dsl.ml
+++ b/src/bigarray/lin_tests_dsl.ml
@@ -42,20 +42,20 @@ struct
   let int = int_small
 
   let api =
-    [ val_ "Bigarray.Array1.create"        array_create         (int @-> returning_ t);
+    [ val_freq 1 "Bigarray.Array1.create"        array_create         (int @-> returning_ t);
       (* [Array1.init] requires a function *)
-      val_ "Bigarray.Array1.dim"           Array1.dim           (t @-> returning int);
+      val_freq 6 "Bigarray.Array1.dim"           Array1.dim           (t @-> returning int);
       (* [Array1.kind] returns an untestable value *)
       (* [change_layout]: the layout is fixed in our sut, so we test a dummy version *)
-      val_ "Bigarray.Array1.change_layout" dummy_change_layout  (t @-> returning_ t);
-      val_ "Bigarray.Array1.size_in_bytes" Array1.size_in_bytes (t @-> returning int);
-      val_ "Bigarray.Array1.get"           Array1.get           (t @-> int @-> returning_or_exc int);
-      val_ "Bigarray.Array1.set"           Array1.set           (t @-> int @-> int @-> returning_or_exc unit);
-      val_ "Bigarray.Array1.sub"           Array1.sub           (t @-> int @-> int @-> returning_or_exc_ t);
+      val_freq 1 "Bigarray.Array1.change_layout" dummy_change_layout  (t @-> returning_ t);
+      val_freq 6 "Bigarray.Array1.size_in_bytes" Array1.size_in_bytes (t @-> returning int);
+      val_freq 6 "Bigarray.Array1.get"           Array1.get           (t @-> int @-> returning_or_exc int);
+      val_freq 6 "Bigarray.Array1.set"           Array1.set           (t @-> int @-> int @-> returning_or_exc unit);
+      val_freq 1 "Bigarray.Array1.sub"           Array1.sub           (t @-> int @-> int @-> returning_or_exc_ t);
       (* [Array1.slice]: cannot be tested since it produces a Bigarray.Array0.t *)
-      val_ "Bigarray.Array1.blit"          Array1.blit          (t @-> t @-> returning unit);
-      val_ "Bigarray.Array1.fill"          Array1.fill          (t @-> int @-> returning unit);
-      val_ "Bigarray.Array1.of_array"      of_array             (bounded_array 100 int @-> returning_ t);
+      val_freq 6 "Bigarray.Array1.blit"          Array1.blit          (t @-> t @-> returning unit);
+      val_freq 6 "Bigarray.Array1.fill"          Array1.fill          (t @-> int @-> returning unit);
+      val_freq 1 "Bigarray.Array1.of_array"      of_array             (bounded_array 100 int @-> returning_ t);
       (* [Array1.unsafe_get] and [Array1.unsafe_set] cannot be tested:
          they can segfault or produce any useless result *)
     ]


### PR DESCRIPTION
Tune the frequencies of Bigarray functions so that the generation of a new array is tried less often: we expect a failing test that arise from race conditions, so reducing the frequency of operations that generate new arrays (and take more resources) helps to trigger the failure