### PR TITLE
Repeat more a few failing tests

### DIFF
--- a/src/bigarray/lin_tests_dsl.ml
+++ b/src/bigarray/lin_tests_dsl.ml
@@ -30,5 +30,5 @@ module BA1T = Lin_api.Make(BA1Conf)
 let _ =
   Util.set_ci_printing () ;
   QCheck_base_runner.run_tests_main [
-    BA1T.neg_lin_test `Domain ~count:1000 ~name:"Lin_api Bigarray.Array1 (of ints) test with Domain";
+    BA1T.neg_lin_test `Domain ~count:5000 ~name:"Lin_api Bigarray.Array1 (of ints) test with Domain";
   ]

--- a/src/neg_tests/domain_lin_tests.ml
+++ b/src/neg_tests/domain_lin_tests.ml
@@ -6,7 +6,7 @@ open Lin_tests_common
 Util.set_ci_printing ()
 ;;
 QCheck_base_runner.run_tests_main
-  (let count = 1000 in
+  (let count = 15000 in
    [RT_int.neg_lin_test    `Domain ~count ~name:"Lin ref int test with Domain";
     RT_int64.neg_lin_test  `Domain ~count ~name:"Lin ref int64 test with Domain";
     CLT_int.neg_lin_test   `Domain ~count ~name:"Lin CList int test with Domain";

--- a/src/neg_tests/thread_lin_tests.ml
+++ b/src/neg_tests/thread_lin_tests.ml
@@ -8,6 +8,6 @@ Util.set_ci_printing ()
 QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.lin_test       `Thread ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    RT_int64.neg_lin_test `Thread ~count ~name:"Lin ref int64 test with Thread";
+    RT_int64.neg_lin_test `Thread ~count:15000 ~name:"Lin ref int64 test with Thread";
     CLT_int.lin_test      `Thread ~count ~name:"Lin CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
     CLT_int64.lin_test    `Thread ~count ~name:"Lin CList int64 test with Thread"]) (* not triggering context switch, unfortunately *)


### PR DESCRIPTION
A few tests that are expected to fail fail only really seldom in some configurations (macos or bytecode, for instance). Since negative tests end up as soon as the expected counter-example is found, increasing the counts is only used in cases where it would have failed (to fail) otherwise