### PR TITLE
CI: Enable opam sandboxing back

### DIFF
--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -21,7 +21,6 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
-          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -21,7 +21,6 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
-          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -23,7 +23,6 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
-          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -23,7 +23,6 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
-          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -23,7 +23,6 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
-          opam-disable-sandboxing: true
           dune-cache: true
 
       - run: opam install . --deps-only --with-test


### PR DESCRIPTION
Since we see a few runs failing on macOS after merging #157, try to fix the problem by enabling back sandboxing. In the failing runs, no dune cache was found so it should probably not be involved (though enabling dune cache triggers its installation early on in the CI run; could this change how other dependencies are built? :thinking:)