### PR TITLE
CI: Share the common part of every CI workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -15,9 +15,21 @@ on:
         description: 'Timeout'
         type: number
         default: 180
+      only_test:
+        description: 'When given, it will run only that executable (might be “src/array/lin_tests.exe”)'
+        type: string
+        default: ''
+      seed:
+        description: 'When running only one test (`only_test` must be set), use that seed'
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
+    env:
+      ONLY_TEST: ${{ inputs.only_test }}
+      SEED: ${{ inputs.seed }}
+
     runs-on: ${{ inputs.runs_on }}
 
     timeout-minutes: ${{ inputs.timeout }}
@@ -44,6 +56,16 @@ jobs:
 
       - name: Build the test suite
         run: opam exec -- dune build
+        if: inputs.only_test == ''
 
       - name: Run the test suite
         run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+        if: inputs.only_test == ''
+
+      - name: Run the one test
+        run: opam exec -- dune exec "$ONLY_TEST" -- -v
+        if: inputs.only_test != '' && inputs.seed == ''
+
+      - name: Run the one test with a fixed seed
+        run: opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED"
+        if: inputs.only_test != '' && inputs.seed != ''

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,12 +23,17 @@ on:
         description: 'Seed for the only test'
         type: string
         default: ''
+      repeats:
+        description: 'Number of test attempts'
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
     env:
       ONLY_TEST: ${{ inputs.only_test }}
       SEED: ${{ inputs.seed }}
+      REPEATS: ${{ inputs.repeats }}
 
     runs-on: ${{ inputs.runs_on }}
 
@@ -64,8 +69,17 @@ jobs:
 
       - name: Run the one test
         run: opam exec -- dune exec "$ONLY_TEST" -- -v
-        if: inputs.only_test != '' && inputs.seed == ''
+        if: inputs.only_test != '' && inputs.seed == '' && inputs.repeats == ''
 
       - name: Run the one test with a fixed seed
         run: opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED"
-        if: inputs.only_test != '' && inputs.seed != ''
+        if: inputs.only_test != '' && inputs.seed != '' && inputs.repeats == ''
+
+      - name: Repeat the one test with a fixed seed
+        run: |
+          failures=0
+          for i in `seq "$REPEATS"; do
+            opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED" || failures=$((failures + 1))
+          done
+          exit "$failures"
+        if: inputs.only_test != '' && inputs.seed != '' && inputs.repeats != ''

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,0 +1,49 @@
+name: Common CI workflow
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: 'Type of machine + OS on which to run the tests'
+        type: string
+        default: 'ubuntu-latest'
+      compiler:
+        description: 'Compiler to use'
+        type: string
+        default: 'ocaml-base-compiler.5.0.0~beta1'
+      timeout:
+        description: 'Timeout'
+        type: number
+        default: 180
+
+jobs:
+  build-and-test:
+    runs-on: ${{ inputs.runs_on }}
+
+    timeout-minutes: ${{ inputs.timeout }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Add dummy binaries to $PATH
+        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Install OCaml compiler ${{ inputs.compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ inputs.compiler }}
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
+          opam-depext: false
+          dune-cache: true
+
+      - name: Install Multicore Tests dependencies
+        run: opam install . --deps-only --with-test
+
+      - name: Build the test suite
+        run: opam exec -- dune build
+
+      - name: Run the test suite
+        run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,11 +16,11 @@ on:
         type: number
         default: 180
       only_test:
-        description: 'When given, it will run only that executable (might be “src/array/lin_tests.exe”)'
+        description: 'Only test to run (eg “src/array/lin_tests.exe”); whole suite is run if empty'
         type: string
         default: ''
       seed:
-        description: 'When running only one test (`only_test` must be set), use that seed'
+        description: 'Seed for the only test'
         type: string
         default: ''
 

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -27,6 +27,10 @@ on:
         description: 'Number of test attempts'
         type: string
         default: ''
+      compiler_commit:
+        description: 'Version (commit) of the OCaml compiler to use'
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
@@ -34,6 +38,7 @@ jobs:
       ONLY_TEST: ${{ inputs.only_test }}
       SEED: ${{ inputs.seed }}
       REPEATS: ${{ inputs.repeats }}
+      OCAML_COMPILER_COMMIT: ${{ inputs.compiler_commit }}
 
     runs-on: ${{ inputs.runs_on }}
 
@@ -55,6 +60,16 @@ jobs:
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
           dune-cache: true
+
+      - name: Override compiler to a particular commit
+        if: inputs.compiler_commit != ''
+        run: |
+          wget "https://github.com/ocaml/ocaml/archive/$OCAML_COMPILER_COMMIT.tar.gz"
+          tar xf "$OCAML_COMPILER_COMMIT.tar.gz"
+          cd "ocaml-$OCAML_COMPILER_COMMIT"
+          opam --cli=2.1 install -y --update-invariant .
+          eval $(opam env)
+          ocamlc -v
 
       - name: Install Multicore Tests dependencies
         run: opam install . --deps-only --with-test

--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -4,25 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0+trunk bytecode only
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-variants.5.0.0+trunk,ocaml-option-bytecode-only
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.0.0+trunk,ocaml-option-bytecode-only'
+      timeout: 360

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -4,25 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0~beta1 bytecode only
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-variants.5.0.0~beta1+options,ocaml-option-bytecode-only
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.0.0~beta1+options,ocaml-option-bytecode-only'
+      timeout: 360

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -4,27 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    timeout-minutes: 180
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0+trunk
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-variants.5.0.0+trunk
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.0.0+trunk'

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -4,27 +4,5 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    timeout-minutes: 180
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0~beta1
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-base-compiler.5.0.0~beta1
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    # default

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -4,27 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: macos-latest
-
-    timeout-minutes: 180
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0+trunk
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-variants.5.0.0+trunk
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.0.0+trunk'
+      runs_on: 'macos-latest'

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -4,28 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: macos-latest
-
-    timeout-minutes: 180
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Add dummy binaries to $PATH
-        run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Use OCaml 5.0.0~beta1
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ocaml-base-compiler.5.0.0~beta1
-          opam-repositories: |
-            default: https://github.com/ocaml/opam-repository.git
-            alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
-          opam-depext: false
-          opam-disable-sandboxing: true
-          dune-cache: true
-
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: 'macos-latest'


### PR DESCRIPTION
These commits introduce a `common.yml` workflow with the few parameters that changes from one actual workflow to the other. It makes their general maintenance easier.
While we’re at it, now that new options are shared between all workflows, add the following options:
- possibility to pick a specific commit of the compiler
- possibility to run (various times if wanted) one specific test with one specific seed, that makes it faster to check bugs for reproducibility.
The first commit is a worthy addition all by itself, I might have added too many options afterwards (even if I found them useful).