### PR TITLE
Add workflow to build gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,43 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main  # Set a branch name to trigger deployment
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v2
+        with:
+          path: ~/.opam
+          key: opam-ubuntu-latest-5.0.0~beta1
+
+      - uses: avsm/setup-ocaml@v2
+        with:
+          ocaml-compiler: 'ocaml-base-compiler.5.0.0~beta1'
+          default: https://github.com/ocaml/opam-repository.git
+          alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
+
+      - name: Pin packages
+        run: opam pin -n .
+
+      - name: Install dependencies
+        run: opam install -d . --deps-only
+
+      - name: Build
+        run: opam exec -- dune build @doc
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/default/_doc/_html/
+          destination_dir: dev
+          enable_jekyll: true


### PR DESCRIPTION
I've now created a separate `gh-pages` branch to host documentation on https://jmid.github.io/multicoretests/
This PR adds a workflow to build the documentation and push it to `gh-pages` upon changes to `main`.
