### PR TITLE
Scope-preserving shrinker for multiple-ts

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -170,9 +170,9 @@ module MakeDomThr(Spec : CmdSpec)
     (* Secondly reduce the cmd data of individual list elements *)
     (fun yield ->
        let seq_env = extract_env [0] seq in (* only extract_env if needed *)
-       (Iter.map (fun p1  -> (seq,p1,p2)) (shrink_individual_cmds (*(extract_env [0] seq)*) seq_env p1)
+       (Iter.map (fun p1  -> (seq,p1,p2)) (shrink_individual_cmds seq_env p1)
         <+>
-        Iter.map (fun p2  -> (seq,p1,p2)) (shrink_individual_cmds (*(extract_env [0] seq)*) seq_env p2))
+        Iter.map (fun p2  -> (seq,p1,p2)) (shrink_individual_cmds seq_env p2))
          yield)
     <+>
     Iter.map (fun seq -> (seq,p1,p2)) (shrink_individual_cmds [0] seq)

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -30,6 +30,7 @@ struct
   type t = Var.t list
   let gen_t_var env = Gen.oneofl env
   let valid_t_vars env v =
+    if v = 0 then Iter.empty else
     match List.filter (fun v' -> v' <= v) env with
     | v' :: _ when v' = v -> Iter.return v
     | env'                ->
@@ -135,7 +136,11 @@ module MakeDomThr(Spec : CmdSpec)
       | [] -> Iter.return []
       | (opt,cmd) :: cmds ->
           let env' = Option.fold ~none:env ~some:(fun i -> i::env) opt in
-          Iter.map2 (fun cmd cmds -> (opt,cmd)::cmds) (Spec.fix_cmd env cmd) (aux env' cmds)
+          (*Iter.map2 (fun cmd cmds -> (opt,cmd)::cmds) (Spec.fix_cmd env cmd) (aux env' cmds)*)
+          Iter.(
+            (map (fun cmd  -> (opt,cmd)::cmds) (Spec.fix_cmd env cmd))
+            <+>
+            (map (fun cmds -> (opt,cmd)::cmds) (aux env' cmds)))
     in aux env cmds
 
   (* Note that the result is built in reverse (ie should be
@@ -151,25 +156,38 @@ module MakeDomThr(Spec : CmdSpec)
     (* Shrinking heuristic:
        First reduce the cmd list sizes as much as possible, since the interleaving
        is most costly over long cmd lists. *)
+    (*
     let concat_map f it = flatten (map f it) in
     let fix_seq seq =
+*)
       let seq_env = extract_env [0] seq in
+(*
       let triple seq p1 p2 = (seq,p1,p2) in
       map triple (fix_cmds [0] seq) <*> fix_cmds seq_env p1 <*> fix_cmds seq_env p2
     in
     let seq_env = extract_env [0] seq in
-
-    concat_map fix_seq (Shrink.list_spine seq)
-    <+>
+    *)
+(*  concat_map fix_seq (Shrink.list_spine seq)
+    <+> *)
     (match p1 with [] -> Iter.empty | c1::c1s -> Iter.return (seq@[c1],c1s,p2))
     <+>
     (match p2 with [] -> Iter.empty | c2::c2s -> Iter.return (seq@[c2],p1,c2s))
     <+>
-    concat_map (fun p1 -> Iter.map (fun p1 -> (seq,p1,p2)) (fix_cmds seq_env p1)) (Shrink.list_spine p1)
+    (map (fun seq' -> (seq',p1,p2)) (Shrink.list_spine seq))
     <+>
-    concat_map (fun p2 -> Iter.map (fun p2 -> (seq,p1,p2)) (fix_cmds seq_env p2)) (Shrink.list_spine p2)
+    (map (fun p1' -> (seq,p1',p2)) (Shrink.list_spine p1))
+    (*concat_map (fun p1 -> Iter.map (fun p1 -> (seq,p1,p2)) (fix_cmds seq_env p1)) (Shrink.list_spine p1)*)
+    <+>
+    (map (fun p2' -> (seq,p1,p2')) (Shrink.list_spine p2))
+    (*concat_map (fun p2 -> Iter.map (fun p2 -> (seq,p1,p2)) (fix_cmds seq_env p2)) (Shrink.list_spine p2)*)
     <+>
     (* Secondly reduce the cmd data of individual list elements *)
+    (map (fun seq -> (seq,p1,p2)) (fix_cmds [0] seq))
+    <+>
+    (map (fun p1  -> (seq,p1,p2)) (fix_cmds seq_env p1))
+    <+>
+    (map (fun p2  -> (seq,p1,p2)) (fix_cmds seq_env p2))
+    <+>
     (map (fun seq' -> (seq',p1,p2)) (Shrink.list_elems shrink_cmd seq))
     <+>
     (map (fun p1' -> (seq,p1',p2)) (Shrink.list_elems shrink_cmd p1))

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -162,7 +162,7 @@ module MakeDomThr(Spec : CmdSpec)
     map (fun p1 -> (seq,p1,p2)) (shrink_cmd_list_spine p1 ctx_doesnt_use_var)
     <+>
     map (fun p2 -> (seq,p1,p2)) (shrink_cmd_list_spine p2 ctx_doesnt_use_var)
-    <+>
+    <+> (* eta-expand the following two to lazily compute the match and @ until/if needed *)
     (fun yield -> (match p1 with [] -> Iter.empty | c1::c1s -> Iter.return (seq@[c1],c1s,p2)) yield)
     <+>
     (fun yield -> (match p2 with [] -> Iter.empty | c2::c2s -> Iter.return (seq@[c2],p1,c2s)) yield)

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -42,34 +42,34 @@ struct
         map  (fun v -> (None, To_seq v)) gen_var;
       ])
 
-  let shrink_cmd c = match c with
-    | Length v     -> Iter.map (fun v -> Length v)    (Var.shrink v)
-    | Get (v,i)    -> Iter.map (fun v -> Get (v,i))   (Var.shrink v)
-    | Set (v,i,c)  -> Iter.map (fun v -> Set (v,i,c)) (Var.shrink v)
+  let shrink_cmd env c = match c with
+    | Length v     -> Iter.map (fun v -> Length v)    (Env.valid_t_vars env v)
+    | Get (v,i)    -> Iter.map (fun v -> Get (v,i))   (Env.valid_t_vars env v)
+    | Set (v,i,c)  -> Iter.map (fun v -> Set (v,i,c)) (Env.valid_t_vars env v)
     | Append (v,w) ->
-      Iter.(map (fun v -> Append (v,w)) (Var.shrink v)
+      Iter.(map (fun v -> Append (v,w)) (Env.valid_t_vars env v)
             <+>
-            map (fun w -> Append (v,w)) (Var.shrink w))
-    | Sub (v,i,l) -> Iter.map (fun v -> Sub (v,i,l)) (Var.shrink v)
-    | Copy v      -> Iter.map (fun v -> Copy v)      (Var.shrink v)
-    | Fill (v,i,l,c) -> Iter.map (fun v -> Fill (v,i,l,c)) (Var.shrink v)
-    | To_list v   -> Iter.map (fun v -> To_list v)   (Var.shrink v)
-    | Mem (v,c)   -> Iter.map (fun v -> Mem (v,c))   (Var.shrink v)
-    | Sort v      -> Iter.map (fun v -> Sort v)      (Var.shrink v)
-    | To_seq v    -> Iter.map (fun v -> To_seq v)    (Var.shrink v)
+            map (fun w -> Append (v,w)) (Env.valid_t_vars env w))
+    | Sub (v,i,l) -> Iter.map (fun v -> Sub (v,i,l)) (Env.valid_t_vars env v)
+    | Copy v      -> Iter.map (fun v -> Copy v)      (Env.valid_t_vars env v)
+    | Fill (v,i,l,c) -> Iter.map (fun v -> Fill (v,i,l,c)) (Env.valid_t_vars env v)
+    | To_list v   -> Iter.map (fun v -> To_list v)   (Env.valid_t_vars env v)
+    | Mem (v,c)   -> Iter.map (fun v -> Mem (v,c))   (Env.valid_t_vars env v)
+    | Sort v      -> Iter.map (fun v -> Sort v)      (Env.valid_t_vars env v)
+    | To_seq v    -> Iter.map (fun v -> To_seq v)    (Env.valid_t_vars env v)
 
-  let fix_cmd env = function
-    | Length i       -> Iter.map (fun i -> Length i      ) (Env.valid_t_vars env i)
-    | Get (i,x)      -> Iter.map (fun i -> Get (i,x)     ) (Env.valid_t_vars env i)
-    | Set (i,x,z)    -> Iter.map (fun i -> Set (i,x,z)   ) (Env.valid_t_vars env i)
-    | Sub (i,x,y)    -> Iter.map (fun i -> Sub (i,x,y)   ) (Env.valid_t_vars env i)
-    | Copy i         -> Iter.map (fun i -> Copy i        ) (Env.valid_t_vars env i)
-    | Fill (i,x,y,z) -> Iter.map (fun i -> Fill (i,x,y,z)) (Env.valid_t_vars env i)
-    | To_list i      -> Iter.map (fun i -> To_list i     ) (Env.valid_t_vars env i)
-    | Mem (i,z)      -> Iter.map (fun i -> Mem (i,z)     ) (Env.valid_t_vars env i)
-    | Sort i         -> Iter.map (fun i -> Sort i        ) (Env.valid_t_vars env i)
-    | To_seq i       -> Iter.map (fun i -> To_seq i      ) (Env.valid_t_vars env i)
-    | Append (i,j)   -> Iter.(map (fun i j -> Append (i,j)) (Env.valid_t_vars env i) <*> (Env.valid_t_vars env j))
+  let cmd_uses_var v c = match c with
+    | Length i
+    | Get (i,_)
+    | Set (i,_,_)
+    | Sub (i,_,_)
+    | Copy i
+    | Fill (i,_,_,_)
+    | To_list i
+    | Mem (i,_)
+    | Sort i
+    | To_seq i -> i=v
+    | Append (i,j) -> i=v || j=v
 
   open Util
   (*let pp_exn = Util.pp_exn*)

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -30,17 +30,17 @@ struct
         map  (fun t ->     (None, Decr t)) gen_var;
       ])
 
-  let shrink_cmd = Shrink.nil
+  let shrink_cmd _env = Shrink.nil
 
-  let fix_cmd env = function
-    | Make x as cmd           -> Iter.return cmd
-    | Get i                   -> Iter.map (fun i -> Get i                  ) (Env.valid_t_vars env i)
-    | Set (i,x)               -> Iter.map (fun i -> Set (i,x)              ) (Env.valid_t_vars env i)
-    | Exchange (i,x)          -> Iter.map (fun i -> Exchange (i,x)         ) (Env.valid_t_vars env i)
-    | Compare_and_set (i,x,y) -> Iter.map (fun i -> Compare_and_set (i,x,y)) (Env.valid_t_vars env i)
-    | Fetch_and_add (i,x)     -> Iter.map (fun i -> Fetch_and_add (i,x)    ) (Env.valid_t_vars env i)
-    | Incr i                  -> Iter.map (fun i -> Incr i                 ) (Env.valid_t_vars env i)
-    | Decr i                  -> Iter.map (fun i -> Decr i                 ) (Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Make _ -> false
+    | Get i
+    | Set (i,_)
+    | Exchange (i,_)
+    | Compare_and_set (i,_,_)
+    | Fetch_and_add (i,_)
+    | Incr i
+    | Decr i -> i=v
 
   type res =
     | RMake of unit

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -8,6 +8,7 @@ module BConf = struct
 
   open Lin_api
   let int = nat_small
+  let string = string_small
 (*let int = int_bound 10*)
 
   let api = [

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -35,7 +35,7 @@ struct
         map2 (fun v c -> None,Mem (v,c)) gen_var gen_char;
         map  (fun v -> None,Length v) gen_var;
       ])
-  let shrink_cmd c = match c with
+  let shrink_cmd _env c = match c with
     | Clear _ -> Iter.empty
     | Copy _ -> Iter.empty
     | Add (v,c,i) ->
@@ -53,17 +53,17 @@ struct
     | Mem (v,c) -> Iter.map (fun c -> Mem (v,c)) (Shrink.char c)
     | Length _ -> Iter.empty
 
-  let fix_cmd env = function
-    | Clear i         -> Iter.map (fun i -> Clear i        ) (Env.valid_t_vars env i)
-    | Copy i          -> Iter.map (fun i -> Copy i         ) (Env.valid_t_vars env i)
-    | Add (i,x,y)     -> Iter.map (fun i -> Add (i,x,y)    ) (Env.valid_t_vars env i)
-    | Remove (i,x)    -> Iter.map (fun i -> Remove (i,x)   ) (Env.valid_t_vars env i)
-    | Find (i,x)      -> Iter.map (fun i -> Find (i,x)     ) (Env.valid_t_vars env i)
-    | Find_opt (i,x)  -> Iter.map (fun i -> Find_opt (i,x) ) (Env.valid_t_vars env i)
-    | Find_all (i,x)  -> Iter.map (fun i -> Find_all (i,x) ) (Env.valid_t_vars env i)
-    | Replace (i,x,y) -> Iter.map (fun i -> Replace (i,x,y)) (Env.valid_t_vars env i)
-    | Mem (i,x)       -> Iter.map (fun i -> Mem (i,x)      ) (Env.valid_t_vars env i)
-    | Length i        -> Iter.map (fun i -> Length i       ) (Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Clear i
+    | Copy i
+    | Add (i,_,_)
+    | Remove (i,_)
+    | Find (i,_)
+    | Find_opt (i,_)
+    | Find_all (i,_)
+    | Replace (i,_,_)
+    | Mem (i,_)
+    | Length i -> i=v
 
   type res =
     | RClear

--- a/src/internal/cleanup_lin.ml
+++ b/src/internal/cleanup_lin.ml
@@ -22,12 +22,12 @@ struct
 	  Gen.map2 (fun t i -> None, Add (t,i)) gen_var int_gen;
          ])
 
-  let shrink_cmd = Shrink.nil
+  let shrink_cmd _env = Shrink.nil
 
-  let fix_cmd env = function
-    | Get i     -> Iter.map (fun i -> Get i    ) (Lin.Env.valid_t_vars env i)
-    | Set (i,x) -> Iter.map (fun i -> Set (i,x)) (Lin.Env.valid_t_vars env i)
-    | Add (i,x) -> Iter.map (fun i -> Add (i,x)) (Lin.Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Get i
+    | Set (i,_)
+    | Add (i,_) -> i=v
 
   let init () = (ref Inited, ref 0)
 

--- a/src/kcas/lin_tests.ml
+++ b/src/kcas/lin_tests.ml
@@ -34,7 +34,18 @@ struct
         map  (fun t     -> None, Decr t) gen_var;
       ])
 
-  let shrink_cmd = Shrink.nil
+  let shrink_cmd _env = Shrink.nil
+
+  let cmd_uses_var v = function
+    | Get i
+    | Set (i,_)
+    | Cas (i,_,_)
+    | TryMapNone i
+    (*| TryMapSome i *)
+    | MapNone i
+    | MapSome i
+    | Incr i
+    | Decr i -> i=v
 
   type res =
     | RGet of int
@@ -103,7 +114,18 @@ struct
         map  (fun t -> None,Decr t) gen_var;
       ])
 
-  let shrink_cmd = Shrink.nil
+  let shrink_cmd _env = Shrink.nil
+
+  let cmd_uses_var v = function
+    | Get i
+    | Set (i,_)
+    | Cas (i,_,_)
+    | TryMapNone i
+    (*| TryMapSome i *)
+    | MapNone i
+    | MapSome i
+    | Incr i
+    | Decr i -> i=v
 
   type res =
     | RGet of int

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -60,14 +60,14 @@ struct
     | Map_val f -> Iter.map (fun f -> Map_val f) (Fn.shrink f)
   *)
   (* the Lazy tests already take a while to run - so better avoid spending extra time shrinking *)
-  let shrink_cmd = Shrink.nil
+  let shrink_cmd _env = Shrink.nil
 
-  let fix_cmd env = function
-    | Force i       -> Iter.map (fun i -> Force i      ) (Env.valid_t_vars env i)
-    | Force_val i   -> Iter.map (fun i -> Force_val i  ) (Env.valid_t_vars env i)
-    | Is_val i      -> Iter.map (fun i -> Is_val i     ) (Env.valid_t_vars env i)
-    | Map (i,f)     -> Iter.map (fun i -> Map (i,f)    ) (Env.valid_t_vars env i)
-    | Map_val (i,f) -> Iter.map (fun i -> Map_val (i,f)) (Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Force i
+    | Force_val i
+    | Is_val i
+    | Map (i,_)
+    | Map_val (i,_) -> i=v
 
   type t = int Lazy.t
 

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -45,19 +45,19 @@ module RConf_int = struct
         map  (fun t -> None,Decr t) gen_var;
       ])
 
-  let shrink_cmd c = match c with
+  let shrink_cmd _env c = match c with
     | Get _
     | Incr _
     | Decr _ -> Iter.empty
     | Set (t,i) -> Iter.map (fun i -> Set (t,i)) (Shrink.int i)
     | Add (t,i) -> Iter.map (fun i -> Add (t,i)) (Shrink.int i)
 
-  let fix_cmd env = function
-    | Get i     -> Iter.map (fun i -> Get i    ) (Env.valid_t_vars env i)
-    | Set (i,x) -> Iter.map (fun i -> Set (i,x)) (Env.valid_t_vars env i)
-    | Add (i,x) -> Iter.map (fun i -> Add (i,x)) (Env.valid_t_vars env i)
-    | Incr i    -> Iter.map (fun i -> Incr i   ) (Env.valid_t_vars env i)
-    | Decr i    -> Iter.map (fun i -> Decr i   ) (Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Get i
+    | Set (i,_)
+    | Add (i,_)
+    | Incr i
+    | Decr i -> i=v
 
   type res = RGet of int | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }, eq]
 
@@ -97,19 +97,19 @@ module RConf_int64 = struct
         map  (fun t -> None,Decr t) gen_var;
       ])
 
-  let shrink_cmd c = match c with
+  let shrink_cmd _env c = match c with
     | Get _
     | Incr _
     | Decr _ -> Iter.empty
     | Set (t,i) -> Iter.map (fun i -> Set (t,i)) (Shrink.int64 i)
     | Add (t,i) -> Iter.map (fun i -> Add (t,i)) (Shrink.int64 i)
 
-  let fix_cmd env = function
-    | Get i     -> Iter.map (fun i -> Get i    ) (Env.valid_t_vars env i)
-    | Set (i,x) -> Iter.map (fun i -> Set (i,x)) (Env.valid_t_vars env i)
-    | Add (i,x) -> Iter.map (fun i -> Add (i,x)) (Env.valid_t_vars env i)
-    | Incr i    -> Iter.map (fun i -> Incr i   ) (Env.valid_t_vars env i)
-    | Decr i    -> Iter.map (fun i -> Decr i   ) (Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Get i
+    | Set (i,_)
+    | Add (i,_)
+    | Incr i
+    | Decr i -> i=v
 
   type res = RGet of int64 | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }, eq]
 
@@ -156,13 +156,13 @@ struct
         map2 (fun t i -> None,Member (t,i)) gen_var gen_int';
       ])
 
-  let shrink_cmd c = match c with
+  let shrink_cmd _env c = match c with
     | Add_node (t,i) -> Iter.map (fun i -> Add_node (t,i)) (T.shrink i)
     | Member (t,i) -> Iter.map (fun i -> Member (t,i)) (T.shrink i)
 
-  let fix_cmd env = function
-    | Add_node (i,x) -> Iter.map (fun i -> Add_node (i,x)) (Lin.Env.valid_t_vars env i)
-    | Member (i,x)   -> Iter.map (fun i -> Member (i,x)  ) (Lin.Env.valid_t_vars env i)
+  let cmd_uses_var v = function
+    | Add_node (i,_)
+    | Member (i,_) -> v=i
 
   type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }, eq]
 

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -32,7 +32,7 @@ module Spec =
           map  (fun t -> None, Length t) gen_var;
         ])
 
-    let shrink_cmd c = match c with
+    let shrink_cmd _env c = match c with
       | Take _
       | Take_opt _
       | Peek _
@@ -47,16 +47,16 @@ module Spec =
             <+>
             (map (fun i -> Fold (t,f,i)) (Shrink.int i)))
 
-    let fix_cmd env = function
-      | Add (i,x)    -> Iter.map (fun i -> Add (i,x)   ) (Env.valid_t_vars env i)
-      | Take i       -> Iter.map (fun i -> Take i      ) (Env.valid_t_vars env i)
-      | Take_opt i   -> Iter.map (fun i -> Take_opt i  ) (Env.valid_t_vars env i)
-      | Peek i       -> Iter.map (fun i -> Peek i      ) (Env.valid_t_vars env i)
-      | Peek_opt i   -> Iter.map (fun i -> Peek_opt i  ) (Env.valid_t_vars env i)
-      | Clear i      -> Iter.map (fun i -> Clear i     ) (Env.valid_t_vars env i)
-      | Is_empty i   -> Iter.map (fun i -> Is_empty i  ) (Env.valid_t_vars env i)
-      | Fold (i,x,y) -> Iter.map (fun i -> Fold (i,x,y)) (Env.valid_t_vars env i)
-      | Length i     -> Iter.map (fun i -> Length i    ) (Env.valid_t_vars env i)
+    let cmd_uses_var v = function
+      | Add (i,_)
+      | Take i
+      | Take_opt i
+      | Peek i
+      | Peek_opt i
+      | Clear i
+      | Is_empty i
+      | Fold (i,_,_)
+      | Length i -> i=v
 
     type res =
       | RAdd

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -33,7 +33,7 @@ module Spec =
           map  (fun t -> None, Length t) gen_var;
         ])
 
-    let shrink_cmd c = match c with
+    let shrink_cmd _env c = match c with
       | Pop _
       | Pop_opt _
       | Top _
@@ -48,16 +48,16 @@ module Spec =
             <+>
             (map (fun i -> Fold (t,f,i)) (Shrink.int i)))
 
-    let fix_cmd env = function
-      | Push (i,x)   -> Iter.map (fun i -> Push (i,x)  ) (Env.valid_t_vars env i)
-      | Pop i        -> Iter.map (fun i -> Pop i       ) (Env.valid_t_vars env i)
-      | Pop_opt i    -> Iter.map (fun i -> Pop_opt i   ) (Env.valid_t_vars env i)
-      | Top i        -> Iter.map (fun i -> Top i       ) (Env.valid_t_vars env i)
-      | Top_opt i    -> Iter.map (fun i -> Top_opt i   ) (Env.valid_t_vars env i)
-      | Clear i      -> Iter.map (fun i -> Clear i     ) (Env.valid_t_vars env i)
-      | Is_empty i   -> Iter.map (fun i -> Is_empty i  ) (Env.valid_t_vars env i)
-      | Fold (i,f,x) -> Iter.map (fun i -> Fold (i,f,x)) (Env.valid_t_vars env i)
-      | Length i     -> Iter.map (fun i -> Length i    ) (Env.valid_t_vars env i)
+    let cmd_uses_var v c = match c with
+      | Push (i,_)
+      | Pop i
+      | Pop_opt i
+      | Top i
+      | Top_opt i
+      | Clear i
+      | Is_empty i
+      | Fold (i,_,_)
+      | Length i -> i=v
 
     type res =
       | RPush


### PR DESCRIPTION
This PR implements a shrinker for `multiple-ts`.
It does so by not removing any `t` variable that later commands may depend on - hence scope preservation.
Overall we replace the built-in `list` shrinker with a custom, `env`-aware shrinker. Like for the `QCheck` `list` shrinker we use the heuristic of reducing the list spine first and individual list elements (cmd arguments) second.

The spine shrinker tries
- one element after another - hence abandoning any clever bisection which shouldn't matter greatly for lists of length at most 20 `cmd`s long
- to remove non-`t` producing `cmd`s
- to remove `t`-producing `cmd`s if they are not used in the enclosing program
- to shrink `cmd` lists starting from the back - from the rationale that later `t`s are less likely to be used as fewer `cmd`s follow and can hence depend on them. This can provide a trickling effect that allow an earlier `t` to be removed in the next round, ...

The shrinker of individual `cmd`s
- first reduces `t` variables to an earlier valid index in the `env`
- secondly reduces non-`t` arguments, thereby avoiding, e.g., having to go through several `string` shrink attempts before getting to a `t` reduction if they were interleaved

I've gone over the latest CI logs and the shrinker seems to work reasonably.