### PR TITLE
Adjust test names

### DIFF
--- a/doc/example/stm_tests.ml
+++ b/doc/example/stm_tests.ml
@@ -62,5 +62,5 @@ module HT_dom = STM_domain.Make(HashtblModel)
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 200 in
-   [HT_seq.agree_test     ~count ~name:"Hashtbl test";
-    HT_dom.agree_test_par ~count ~name:"Hashtbl test"; ])
+   [HT_seq.agree_test     ~count ~name:"Hashtbl test sequential";
+    HT_dom.agree_test_par ~count ~name:"Hashtbl test parallel"; ])

--- a/doc/paper-examples/stm_tests.ml
+++ b/doc/paper-examples/stm_tests.ml
@@ -73,6 +73,6 @@ module HT_dom = STM_domain.Make(HashtblModel)
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 200 in
-   [HT_seq.agree_test       ~count ~name:"Hashtbl test";
-    HT_dom.agree_test_par   ~count ~name:"Hashtbl test";
+   [HT_seq.agree_test       ~count ~name:"Hashtbl test sequential";
+    HT_dom.agree_test_par   ~count ~name:"Hashtbl test parallel";
    ])

--- a/src/domainslib/chan_stm_tests.ml
+++ b/src/domainslib/chan_stm_tests.ml
@@ -73,7 +73,7 @@ module ChT_seq = STM_sequential.Make(ChConf)
 module ChT_dom = STM_domain.Make(ChConf)
 ;;
 QCheck_base_runner.run_tests_main
-  (let count,name = 500,"global Domainslib.Chan test" in [
-      ChT_seq.agree_test     ~count ~name;
-      ChT_dom.agree_test_par ~count ~name;
-    ])
+  (let count = 500 in
+   [ChT_seq.agree_test     ~count ~name:"STM Domainslib.Chan test sequential";
+    ChT_dom.agree_test_par ~count ~name:"STM Domainslib.Chan test parallel";
+   ])

--- a/src/domainslib/task_more_deps.ml
+++ b/src/domainslib/task_more_deps.ml
@@ -91,7 +91,7 @@ let build_dep_graph pool test_input =
   build 0 []
 
 let test_one_pool ~domain_bound ~promise_bound =
-  Test.make ~name:"Task.async/await, more deps, 1 work pool" ~count:100
+  Test.make ~name:"Domainslib.Task.async/await, more deps, 1 work pool" ~count:100
     (arb_deps domain_bound promise_bound)
     ((*Util.fork_prop_with_timeout 10*)
      Util.repeat 10

--- a/src/domainslib/task_one_dep.ml
+++ b/src/domainslib/task_one_dep.ml
@@ -115,8 +115,7 @@ let build_dep_graph pool test_input =
   build 0 []
 
 let test_one_pool ~domain_bound ~promise_bound =
-  Test.make ~name:"Task.async/await, one dep, 1 work pool" ~count:100
-  (*Test.make ~retries:50 ~name:"Task.async/await" ~count:100*)
+  Test.make ~name:"Domainslib.Task.async/await, one dep, 1 work pool" ~count:100
     (arb_deps domain_bound promise_bound)
     ((*Util.fork_prop_with_timeout 10*)
       Util.repeat 10 @@
@@ -132,7 +131,7 @@ let test_one_pool ~domain_bound ~promise_bound =
 
 let test_two_pools_sync_last ~domain_bound ~promise_bound =
   let gen = arb_deps domain_bound promise_bound in
-  Test.make ~name:"Task.async/await, one dep, w.2 pools, syncing at the end" ~count:100
+  Test.make ~name:"Domainslib.Task.async/await, one dep, w.2 pools, syncing at the end" ~count:100
     (pair gen gen)
     ((*Util.fork_prop_with_timeout 10 @@*)
      Util.repeat 10 @@
@@ -151,7 +150,7 @@ let test_two_pools_sync_last ~domain_bound ~promise_bound =
 
 let test_two_nested_pools ~domain_bound ~promise_bound =
   let gen = arb_deps domain_bound promise_bound in
-  Test.make ~name:"Task.async/await, one dep, w.2 nested pools" ~count:100
+  Test.make ~name:"Domainslib.Task.async/await, one dep, w.2 nested pools" ~count:100
     (pair gen gen)
     ((*Util.fork_prop_with_timeout 10 @@*)
      Util.repeat 10 @@

--- a/src/domainslib/task_parallel.ml
+++ b/src/domainslib/task_parallel.ml
@@ -20,7 +20,7 @@ let scan_task num_doms array_size =
 let count = 250
 
 let test_parallel_for =
-  Test.make ~name:"test Task.parallel_for" ~count
+  Test.make ~name:"Domainslib.Task.parallel_for test" ~count
     (triple (int_bound 10) small_nat small_nat)
     (fun (num_domains,array_size,chunk_size) ->
        (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)
@@ -33,7 +33,7 @@ let test_parallel_for =
        res = array_size)
 
 let test_parallel_for_reduce =
-  Test.make ~name:"test Task.parallel_for_reduce" ~count
+  Test.make ~name:"Domainslib.Task.parallel_for_reduce test" ~count
     (triple (int_bound 10) small_nat small_nat)
     (fun (num_domains,array_size,chunk_size) ->
        (*Printf.printf "(%i,%i,%i)\n%!" num_domains array_size chunk_size;*)
@@ -44,7 +44,7 @@ let test_parallel_for_reduce =
        res = array_size)
 
 let test_parallel_scan =
-  Test.make ~name:"test Task.parallel_scan" ~count
+  Test.make ~name:"Domainslib.Task.parallel_scan test" ~count
     (pair (int_bound 10) small_nat)
     (fun (num_domains,array_size) ->
        (*Printf.printf "(%i,%i)\n%!" num_domains array_size;*)

--- a/src/lockfree/ws_deque_test.ml
+++ b/src/lockfree/ws_deque_test.ml
@@ -100,7 +100,7 @@ let agree_test_par_negative ~count ~name = WSDT_dom.neg_agree_test_par ~count ~n
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 1000 in [
-    WSDT_seq.agree_test     ~count ~name:"sequential ws_deque test";
-    agree_test_par          ~count ~name:"parallel ws_deque test";
-    agree_test_par_negative ~count ~name:"parallel ws_deque test, negative";
+    WSDT_seq.agree_test     ~count ~name:"STM Lockfree.Ws_deque test sequential";
+    agree_test_par          ~count ~name:"STM Lockfree.Ws_deque test parallel";
+    agree_test_par_negative ~count ~name:"STM Lockfree.Ws_deque test parallel, negative";
   ])


### PR DESCRIPTION
Having scanned CI logs repeatedly I wished for more uniform test names, so that after a change to `STM` or `Lin_api` it was easier to quickly determine whether a given test had been affected by the change or not.

This PR adjusts some of the less clear test names to help with that.