### PR TITLE
Correct STM docs

### DIFF
--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -26,7 +26,7 @@ module Make : functor (Spec : STM_base.Spec) ->
     (** Parallel agreement test based on [Domain] which combines [repeat] and [~retries] *)
 
     val neg_agree_test_par : count:int -> name:string -> QCheck.Test.t
-    (** An negative agreement test (for convenience). Accepts two labeled parameters:
+    (** A negative agreement test (for convenience). Accepts two labeled parameters:
         [count] is the test count and [name] is the printed test name. *)
 
  end

--- a/lib/STM_internal.mli
+++ b/lib/STM_internal.mli
@@ -1,7 +1,6 @@
 open QCheck
 open STM_spec
-(** A revised state machine framework with parallel testing.
-    This version does not come with built-in GC commands. *)
+(** Internal helper module to build STM tests. *)
 
 
 (** Derives a test framework from a state machine specification. *)

--- a/lib/STM_sequential.mli
+++ b/lib/STM_sequential.mli
@@ -21,6 +21,6 @@ module Make : functor (Spec : STM_base.Spec) ->
         [count] is the test count and [name] is the printed test name. *)
 
     val neg_agree_test : count:int -> name:string -> QCheck.Test.t
-    (** An negative agreement test (for convenience). Accepts two labeled parameters:
+    (** A negative agreement test (for convenience). Accepts two labeled parameters:
         [count] is the test count and [name] is the printed test name. *)
   end

--- a/lib/STM_spec.mli
+++ b/lib/STM_spec.mli
@@ -1,3 +1,5 @@
+(** Module with combinators and definitions to specify an STM test *)
+
 (** Extensible type to represent result values *)
 type 'a ty = ..
 

--- a/lib/STM_thread.mli
+++ b/lib/STM_thread.mli
@@ -15,7 +15,7 @@ module Make : functor (Spec : STM_base.Spec) ->
     (** Concurrent agreement test based on [Thread] which combines [repeat] and [~retries] *)
 
     val neg_agree_test_conc : count:int -> name:string -> QCheck.Test.t
-    (** An negative agreement test (for convenience). Accepts two labeled parameters:
+    (** A negative agreement test (for convenience). Accepts two labeled parameters:
         [count] is the test count and [name] is the printed test name. *)
 
   end


### PR DESCRIPTION
This little documentation PR
- corrects a module header for `STM_internal`
- adds a module header for `STM_spec`
- corrects a typo (*an negative*)