### PR TITLE
Add missing test aliases

### DIFF
--- a/src/array/dune
+++ b/src/array/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (deps
    stm_tests.exe
-   lin_tests.exe
+   lin_tests.exe ;; currently not run on CI
    lin_tests_dsl.exe))
 
 (executable

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -4,7 +4,10 @@
 (alias
  (name default)
  (package multicoretests)
- (deps stm_tests.exe lin_tests.exe lin_tests_dsl.exe))
+ (deps
+   stm_tests.exe
+   lin_tests.exe ;; currently not run on CI
+   lin_tests_dsl.exe))
 
 
 ;; STM_sequential and STM_domain test of Atomic

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -5,7 +5,9 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests_dsl.exe))
+ (deps
+   stm_tests.exe ;; currently not run on CI
+   lin_tests_dsl.exe))
 
 (executable
  (name lin_tests_dsl)

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -5,7 +5,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests_dsl.exe))
+ (deps stm_tests.exe lin_tests_dsl.exe))
 
 ;; Linearizability tests
 

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,9 @@
 (alias
  (name default)
  (package multicoretests)
- (deps (alias neg_tests/default)
+ (deps ;; internal framework testing
+       (alias internal/default)
+       (alias neg_tests/default)
        ;; stdlib, in alphabetic order
        (alias array/default)
        (alias atomic/default)
@@ -15,8 +17,10 @@
        (alias hashtbl/default)
        (alias lazy/default)
        (alias queue/default)
+       (alias semaphore/default)
        (alias stack/default)
        (alias thread/default)
+       (alias threadomain/default)
        ;; other libs
        (alias domainslib/default)
        (alias lockfree/default)

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (deps
    stm_tests.exe
-   lin_tests.exe
+   lin_tests.exe ;; currently not run on CI
    lin_tests_dsl.exe))
 
 (executable

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -4,7 +4,10 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe stm_tests.exe lin_tests_dsl.exe))
+ (deps
+   lin_tests.exe ;; currently not run on CI
+   stm_tests.exe
+   lin_tests_dsl.exe)) ;; currently not run on CI
 
 (executable
  (name stm_tests)

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -5,13 +5,19 @@
  (name default)
  (package multicoretests)
  (deps
+   ;; STM tests
    ref_stm_seq_tests.exe
    ref_stm_dom_tests.exe
    ref_stm_thread_tests.exe
    conclist_stm_tests.exe
-   domain_lin_tests_dsl.exe
+   ;; Lin tests
+   domain_lin_tests.exe ;; currently not run on CI
+   effect_lin_tests.exe ;; currently not run on CI
    thread_lin_tests.exe
-   effect_lin_tests_dsl.exe))
+   ;; Lin_api tests
+   domain_lin_tests_dsl.exe
+   effect_lin_tests_dsl.exe
+   thread_lin_tests_dsl.exe)) ;; currently not run on CI
 
 (library
  (name ref_stm_spec)

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -4,7 +4,9 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe lin_tests_dsl.exe))
+ (deps
+   lin_tests.exe ;; currently not run on CI
+   lin_tests_dsl.exe))
 
 (executable
  (name lin_tests_dsl)

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -4,7 +4,9 @@
 (alias
  (name default)
  (package multicoretests)
- (deps lin_tests.exe lin_tests_dsl.exe))
+ (deps
+   lin_tests.exe ;; currently not run on CI
+   lin_tests_dsl.exe))
 
 (executable
  (name lin_tests_dsl)


### PR DESCRIPTION
This PR
- adds missing test directory aliases to `src/dune`
- adds default aliases so that we build **all** tests by default (to ensure against breakage)
- annotates aliases that are currently not run, for future reference (e.g., if we want to have multiple aliases)

Overall this should fix #184 

I'm wondering if not having to interleave compiler invocations and test runs will also have an effect on #179 (CC @shym)