### PR TITLE
CI: Set caching based on the actual upstream compiler commit

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -11,6 +11,10 @@ on:
         description: 'Compiler to use'
         type: string
         default: 'ocaml-base-compiler.5.0.0~beta1'
+      compiler_branch:
+        description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
+        type: string
+        default: ''
       timeout:
         description: 'Timeout'
         type: number
@@ -39,6 +43,7 @@ jobs:
       SEED: ${{ inputs.seed }}
       REPEATS: ${{ inputs.repeats }}
       OCAML_COMPILER_COMMIT: ${{ inputs.compiler_commit }}
+      OCAML_COMPILER_BRANCH: ${{ inputs.compiler_branch }}
 
     runs-on: ${{ inputs.runs_on }}
 
@@ -51,6 +56,17 @@ jobs:
       - name: Add dummy binaries to $PATH
         run: echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
 
+      - name: Pick up a robust cache prefix
+        id: compute_prefix
+        shell: bash
+        run: |
+          if [ -n "$OCAML_COMPILER_BRANCH" ]; then
+            echo "cache_prefix=$(curl -sH "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/ocaml/ocaml/commits/$OCAML_COMPILER_BRANCH" | jq -r .commit.tree.sha)" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_prefix=v1" >> "$GITHUB_OUTPUT"
+          fi
+          cat "$GITHUB_OUTPUT"
+
       - name: Install OCaml compiler ${{ inputs.compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
@@ -60,6 +76,7 @@ jobs:
             alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
           opam-depext: false
           dune-cache: true
+          cache-prefix: ${{ steps.compute_prefix.outputs.cache_prefix }}
 
       - name: Override compiler to a particular commit
         if: inputs.compiler_commit != ''

--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -7,4 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.0.0+trunk,ocaml-option-bytecode-only'
+      compiler_branch: '5.0'
       timeout: 360

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -7,3 +7,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.0.0+trunk'
+      compiler_branch: '5.0'

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -7,4 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.0.0+trunk'
+      compiler_branch: '5.0'
       runs_on: 'macos-latest'


### PR DESCRIPTION
The opam cache set up by `setup-ocaml` assumes that the compiler version is enough to ensure that the proper compiler is in use, but this assumption is not true for `trunk` compilers. So this adds an optional key to the common workflow so that the `cache-prefix` key is either set to v1 or to the hash of the current upstream compiler.

This also adds the benefit of logging the current commit id of the compiler used by that CI run.

Note that this PR has no impact on the Windows-CI PR, since that one always builds the OCaml compiler from sources.