### PR TITLE
CI: Limit the parallelism on macOS runners

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -89,7 +89,12 @@ jobs:
           ocamlc -v
 
       - name: Install Multicore Tests dependencies
-        run: opam install . --deps-only --with-test
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            opam install . --deps-only --with-test -j1
+          else
+            opam install . --deps-only --with-test
+          fi
 
       - name: Set QCHECK_MSG_INTERVAL to reduce noise and keep CI logs tidy
         run: echo "QCHECK_MSG_INTERVAL=60" >> $GITHUB_ENV


### PR DESCRIPTION
We see many runs on macOS failing on SIGKILL during the compilation of dependencies, which might be a sign that their build might exceed the ressources of the runner, so we remove parallelism during that phase.

The builds went ok on pushing to my fork. Let see if that works on the builds for the PR.