### PR TITLE
CI configuration for running a single test

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Repeat the one test with a fixed seed
         run: |
           failures=0
-          for i in `seq "$REPEATS"; do
+          for i in `seq "$REPEATS"`; do
             opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED" || failures=$((failures + 1))
           done
           exit "$failures"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -26,7 +26,7 @@ on:
       repeats:
         description: 'Number of test attempts'
         type: string
-        default: ''
+        default: '10'
       compiler_commit:
         description: 'Version (commit) of the OCaml compiler to use'
         type: string
@@ -85,19 +85,16 @@ jobs:
         run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
         if: inputs.only_test == ''
 
-      - name: Run the one test
-        run: opam exec -- dune exec "$ONLY_TEST" -- -v
-        if: inputs.only_test != '' && inputs.seed == '' && inputs.repeats == ''
-
-      - name: Run the one test with a fixed seed
-        run: opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED"
-        if: inputs.only_test != '' && inputs.seed != '' && inputs.repeats == ''
-
-      - name: Repeat the one test with a fixed seed
+      - name: Run only one test
         run: |
           failures=0
           for i in `seq "$REPEATS"`; do
-            opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED" || failures=$((failures + 1))
+            if [ -n "$SEED" ]; then
+              opam exec -- dune exec "$ONLY_TEST" -- -v -s "$SEED" || failures=$((failures + 1))
+            else
+              opam exec -- dune exec "$ONLY_TEST" -- -v || failures=$((failures + 1))
+            fi
           done
-          exit "$failures"
-        if: inputs.only_test != '' && inputs.seed != '' && inputs.repeats != ''
+          echo "Test failed $failures times"
+          [ "$failures" = 0 ]
+        if: inputs.only_test != ''


### PR DESCRIPTION
Setting up a full CI run for a single test is expensive: we should make the most of it by running it a couple of times, either to check for the reproducibility of a given seed or to look for seeds that produce failures.
Merging all the steps also makes logs a bit cleaner for normal runs, where only that step will be skipped.