### PR TITLE
More post-refactor Lin polishing

### DIFF
--- a/doc/paper-examples/dune
+++ b/doc/paper-examples/dune
@@ -3,7 +3,7 @@
 (executable
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin))
+ (libraries qcheck-lin.domain))
 
 
 ;; A model-based test of the stdlib Hashtbl library

--- a/doc/paper-examples/lin_tests_dsl.ml
+++ b/doc/paper-examples/lin_tests_dsl.ml
@@ -8,7 +8,7 @@ struct
   let init () = Hashtbl.create ~random:false 42
   let cleanup _ = ()
 
-  open Lin_api
+  open Lin_base
   let a,b = char_printable,nat_small
   let api =
     [ val_ "Hashtbl.clear"    Hashtbl.clear    (t @-> returning unit);
@@ -21,8 +21,8 @@ struct
     ]
 end
 
-module HT = Lin_api.Make(HashtblSig)
+module HT = Lin_domain.Make(HashtblSig)
 ;;
 QCheck_base_runner.run_tests_main [
-  HT.lin_test     `Domain ~count:1000 ~name:"Hashtbl DSL test";
+  HT.lin_test ~count:1000 ~name:"Hashtbl DSL test";
 ]

--- a/lib/lin_domain.ml
+++ b/lib/lin_domain.ml
@@ -35,5 +35,5 @@ module Make_internal (Spec : Lin_internal.CmdSpec) = struct
     neg_lin_test ~rep_count:50 ~count ~retries:3 ~name ~lin_prop:lin_prop_domain
 end
 
-module Make (Spec : Lin_common.ApiSpec) =
+module Make (Spec : ApiSpec) =
   Make_internal(Lin_common.MakeCmd(Spec))

--- a/lib/lin_domain.mli
+++ b/lib/lin_domain.mli
@@ -1,0 +1,26 @@
+open Lin_base
+
+(** functor to build an internal module representing parallel tests *)
+module Make_internal (Spec : Lin_internal.CmdSpec) : sig
+  val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
+  val lin_prop_domain : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+end
+
+(** functor to build a module for parallel testing *)
+module Make (Spec : ApiSpec) : sig
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [lin_test ~count:c ~name:n] builds a parallel test with the name [n] that
+      iterates [c] times. The test fails if one of the generated programs is not
+      sequentially consistent. In that case it fails, and prints a reduced
+      counter example.
+  *)
+
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [neg_lin_test ~count:c ~name:n] builds a negative parallel test with the
+      name [n] that iterates [c] times. The test fails if no counter example is
+      found, and succeeds if a counter example is indeed found, and prints it
+      afterwards.
+  *)
+end

--- a/lib/lin_effect.ml
+++ b/lib/lin_effect.ml
@@ -122,5 +122,5 @@ module Make_internal (Spec : Lin_internal.CmdSpec) = struct
       arb_cmd_triple (Util.repeat rep_count lin_prop_effect)
 end
 
-module Make (Spec : Lin_common.ApiSpec) =
+module Make (Spec : ApiSpec) =
   Make_internal(Lin_common.MakeCmd(Spec))

--- a/lib/lin_effect.mli
+++ b/lib/lin_effect.mli
@@ -1,0 +1,36 @@
+open Lin_base
+
+(** functor to build an internal module representing effect-based tests *)
+module Make_internal (Spec : Lin_internal.CmdSpec) : sig
+  module EffSpec : sig
+    type cmd
+  end
+  val lin_prop_effect : (EffSpec.cmd list * EffSpec.cmd list * EffSpec.cmd list) -> bool
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+end
+
+val fork : (unit -> unit) -> unit
+(** Helper function to fork a process in the underlying [Effect-based] scheduler
+*)
+
+val yield : unit -> unit
+(** Helper function to yield control in the underlying [Effect-based] scheduler
+*)
+
+(** functor to build a module for [Effect]-based testing *)
+module Make (Spec : ApiSpec) : sig
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [lin_test ~count:c ~name:n] builds an [Effect]-based test with the name
+      [n] that iterates [c] times. The test fails if one of the generated
+      programs is not sequentially consistent. In that case it fails, and prints
+      a reduced counter example.
+  *)
+
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [neg_lin_test ~count:c ~name:n] builds a negative [Effect]-based test with
+      the name [n] that iterates [c] times. The test fails if no counter example
+      is found, and succeeds if a counter example is indeed found, and prints it
+      afterwards.
+  *)
+end

--- a/lib/lin_thread.ml
+++ b/lib/lin_thread.ml
@@ -42,5 +42,5 @@ module Make_internal (Spec : Lin_internal.CmdSpec) = struct
     neg_lin_test ~rep_count:100 ~count ~retries:5 ~name ~lin_prop:lin_prop_thread
 end
 
-module Make (Spec : Lin_common.ApiSpec) =
+module Make (Spec : ApiSpec) =
   Make_internal(Lin_common.MakeCmd(Spec))

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -1,0 +1,26 @@
+open Lin_base
+
+(** functor to build an internal module representing concurrent tests *)
+module Make_internal (Spec : Lin_internal.CmdSpec) : sig
+  val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
+  val lin_prop_thread : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+end
+
+(** functor to build a module for concurrent testing *)
+module Make (Spec : ApiSpec) : sig
+  val lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [lin_test ~count:c ~name:n] builds a concurrent test with the name [n]
+      that iterates [c] times. The test fails if one of the generated programs
+      is not sequentially consistent. In that case it fails, and prints a
+      reduced counter example.
+  *)
+
+  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+  (** [neg_lin_test ~count:c ~name:n] builds a negative concurrent test with
+      the name [n] that iterates [c] times. The test fails if no counter example
+      is found, and succeeds if a counter example is indeed found, and prints it
+      afterwards.
+  *)
+end


### PR DESCRIPTION
This PR
- simplifies the `{Lin_domain,Lin_thread,Lin_effect}.Make` type annotation
- adds minimal interfaces for  `Lin_domain`, `Lin_thread`, and `Lin_effect`
- updates the doc/paper-examples/lin_tests_dsl code