### PR TITLE
Alerts internal

### DIFF
--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -187,8 +187,11 @@ sig
         sequential commands and at most [par_len] parallel commands each.
         The three [cmd] components are generated with [arb0], [arb1], and [arb2], respectively.
         Each of these take the model state as a parameter. *)
-  end
 end
+  [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
+
+end
+
 
 val protect : ('a -> 'b) -> 'a -> ('b, exn) result
 (** [protect f] turns an [exception] throwing function into a [result] returning function. *)

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -5,6 +5,7 @@ module Make (Spec: Spec) = struct
   open Util
   open QCheck
   open Internal.Make(Spec)
+    [@alert "-internal"]
 
   let check_obs = check_obs
   let arb_cmds_par = arb_cmds_par

--- a/lib/STM_sequential.ml
+++ b/lib/STM_sequential.ml
@@ -4,6 +4,7 @@ module Make (Spec: Spec) = struct
 
   open QCheck
   open Internal.Make(Spec)
+    [@alert "-internal"]
 
   (* re-export some functions *)
   let cmds_ok        = cmds_ok

--- a/lib/STM_thread.ml
+++ b/lib/STM_thread.ml
@@ -5,6 +5,7 @@ module Make (Spec: Spec) = struct
   open Util
   open QCheck
   open Internal.Make(Spec)
+    [@alert "-internal"]
 
   exception ThreadNotFinished
 

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -293,6 +293,6 @@ end
 
 (** {1 Generation of linearizability testing module from an API} *)
 
-module MakeCmd (Spec : Spec) : Internal.CmdSpec
+module MakeCmd (Spec : Spec) : Internal.CmdSpec [@alert "-internal"]
 (** Functor to map a combinator-based module signature description
     into a raw [Lin] description *)

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -51,7 +51,8 @@ module Internal : sig
 
   val pp_exn : Format.formatter -> exn -> unit
   (** Format-based exception pretty printer *)
- end
+end
+  [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 
 (** {1 Type-representing values} *)

--- a/lib/lin_domain.ml
+++ b/lib/lin_domain.ml
@@ -1,7 +1,7 @@
 open Lin
 
-module Make_internal (Spec : Internal.CmdSpec) = struct
-  module M = Internal.Make(Spec)
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
+  module M = Internal.Make(Spec) [@alert "-internal"]
   include M
 
   (* operate over arrays to avoid needless allocation underway *)

--- a/lib/lin_domain.mli
+++ b/lib/lin_domain.mli
@@ -1,7 +1,7 @@
 open Lin
 
 (** functor to build an internal module representing parallel tests *)
-module Make_internal (Spec : Internal.CmdSpec) : sig
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
   val lin_prop_domain : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
   val lin_test : count:int -> name:string -> QCheck.Test.t

--- a/lib/lin_domain.mli
+++ b/lib/lin_domain.mli
@@ -7,6 +7,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   val neg_lin_test : count:int -> name:string -> QCheck.Test.t
 end
+  [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 (** functor to build a module for parallel testing *)
 module Make (Spec : Spec) : sig

--- a/lib/lin_effect.ml
+++ b/lib/lin_effect.ml
@@ -33,7 +33,7 @@ let start_sched main =
 let fork f = perform (Fork f)
 let yield () = perform Yield
 
-module Make_internal (Spec : Internal.CmdSpec) = struct
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
 
 
   (** A refined [CmdSpec] specification with generator-controlled [Yield] effects *)
@@ -79,7 +79,7 @@ module Make_internal (Spec : Internal.CmdSpec) = struct
           UserRes res
   end
 
-  module EffTest = Internal.Make(EffSpec)
+  module EffTest = Internal.Make(EffSpec) [@alert "-internal"]
 
   let filter_res rs = List.filter (fun (c,_) -> c <> EffSpec.SchedYield) rs
 

--- a/lib/lin_effect.mli
+++ b/lib/lin_effect.mli
@@ -1,7 +1,7 @@
 open Lin
 
 (** functor to build an internal module representing effect-based tests *)
-module Make_internal (Spec : Internal.CmdSpec) : sig
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   module EffSpec : sig
     type cmd
   end

--- a/lib/lin_effect.mli
+++ b/lib/lin_effect.mli
@@ -9,6 +9,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   val neg_lin_test : count:int -> name:string -> QCheck.Test.t
 end
+  [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 val fork : (unit -> unit) -> unit
 (** Helper function to fork a process in the underlying [Effect-based] scheduler

--- a/lib/lin_thread.ml
+++ b/lib/lin_thread.ml
@@ -1,7 +1,7 @@
 open Lin
 
-module Make_internal (Spec : Internal.CmdSpec) = struct
-  module M = Internal.Make(Spec)
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
+  module M = Internal.Make(Spec) [@alert "-internal"]
   include M
 
   (* Note: On purpose we use

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -1,7 +1,7 @@
 open Lin
 
 (** functor to build an internal module representing concurrent tests *)
-module Make_internal (Spec : Internal.CmdSpec) : sig
+module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val arb_cmds_par : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
   val lin_prop_thread : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
   val lin_test : count:int -> name:string -> QCheck.Test.t

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -7,6 +7,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   val neg_lin_test : count:int -> name:string -> QCheck.Test.t
 end
+  [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 (** functor to build a module for concurrent testing *)
 module Make (Spec : Spec) : sig

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -56,7 +56,7 @@ struct
   let cleanup _ = ()
 end
 
-module AT_domain = Lin_domain.Make_internal(AConf)
+module AT_domain = Lin_domain.Make_internal(AConf) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main [
   AT_domain.neg_lin_test ~count:1000 ~name:"Lin Array test with Domain";

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -42,7 +42,7 @@ struct
   let cleanup _ = ()
 end
 
-module AT_domain = Lin_domain.Make_internal(AConf)
+module AT_domain = Lin_domain.Make_internal(AConf) [@alert "-internal"]
 
 (** A variant of the above with 3 Atomics *)
 module A3Conf =
@@ -85,7 +85,7 @@ struct
   let cleanup _ = ()
 end
 
-module A3T_domain = Lin_domain.Make_internal(A3Conf)
+module A3T_domain = Lin_domain.Make_internal(A3Conf) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main [
   AT_domain.lin_test  ~count:1000 ~name:"Lin Atomic test with Domain";

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -1,5 +1,5 @@
 open QCheck
-open Lin.Internal
+open Lin.Internal [@@alert "-internal"]
 
 (** ********************************************************************** *)
 (**                      Tests of thread-unsafe [Hashtbl]                  *)

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -65,7 +65,7 @@ struct
   let cleanup _ = ()
 end
 
-module HT_domain = Lin_domain.Make_internal(HConf)
+module HT_domain = Lin_domain.Make_internal(HConf) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main [
   HT_domain.neg_lin_test ~count:1000 ~name:"Lin Hashtbl test with Domain";

--- a/src/internal/cleanup.ml
+++ b/src/internal/cleanup.ml
@@ -39,7 +39,7 @@ struct
     | Add i -> (let old = !r in r := i + old; RAdd) (* buggy: not atomic *)
 end
 
-module RT = Lin_domain.Make_internal(RConf)
+module RT = Lin_domain.Make_internal(RConf) [@alert "-internal"]
 ;;
 Test.check_exn
   (let seq_len,par_len = 20,15 in

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -78,15 +78,15 @@ end
 module LTlazy    = Lin_domain.Make_internal(struct
     include LBase
     let init () = lazy (work ())
-  end)
+  end) [@alert "-internal"]
 module LTfromval = Lin_domain.Make_internal(struct
     include LBase
     let init () = Lazy.from_val 42
-  end)
+  end) [@alert "-internal"]
 module LTfromfun = Lin_domain.Make_internal(struct
     include LBase
     let init () = Lazy.from_fun work
-  end)
+  end) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 100 in

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -32,7 +32,7 @@ module Lazy :
 
 module LBase =
 struct
-  open Lin.Internal
+  open Lin.Internal [@@alert "-internal"]
   type cmd =
     | Force
     | Force_val

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -103,7 +103,7 @@ module CLConf (T : sig
                      val shrink : t Shrink.t
                    end) =
 struct
-  module Lin = Lin.Internal
+  module Lin = Lin.Internal [@alert "-internal"]
 
   type t = T.t CList.conc_list Atomic.t
   type int' = T.t

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -88,8 +88,8 @@ module RConf_int64 = struct
   let cleanup _ = ()
 end
 
-module RT_int_domain = Lin_domain.Make_internal(RConf_int)
-module RT_int64_domain = Lin_domain.Make_internal(RConf_int64)
+module RT_int_domain = Lin_domain.Make_internal(RConf_int) [@alert "-internal"]
+module RT_int64_domain = Lin_domain.Make_internal(RConf_int64) [@alert "-internal"]
 
 
 (** ********************************************************************** *)
@@ -139,5 +139,5 @@ module Int64 = struct
   include Stdlib.Int64
   let shrink = Shrink.int64
 end
-module CLT_int_domain = Lin_domain.Make_internal(CLConf (Int))
-module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64))
+module CLT_int_domain = Lin_domain.Make_internal(CLConf (Int)) [@alert "-internal"]
+module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64)) [@alert "-internal"]

--- a/src/neg_tests/lin_tests_effect.ml
+++ b/src/neg_tests/lin_tests_effect.ml
@@ -21,8 +21,8 @@ struct
     | Decr  -> (Sut_int.decr r; RDecr)
 end
 
-module RT_int_effect = Lin_effect.Make_internal(RConf_int)
-module RT_int'_effect = Lin_effect.Make_internal(RConf_int')
+module RT_int_effect = Lin_effect.Make_internal(RConf_int) [@alert "-internal"]
+module RT_int'_effect = Lin_effect.Make_internal(RConf_int') [@alert "-internal"]
 
 module RConf_int64' =
 struct
@@ -36,8 +36,8 @@ struct
     | Incr  -> (Sut_int64.incr r; RIncr)
     | Decr  -> (Sut_int64.decr r; RDecr)
 end
-module RT_int64_effect = Lin_effect.Make_internal(RConf_int64)
-module RT_int64'_effect = Lin_effect.Make_internal(RConf_int64')
+module RT_int64_effect = Lin_effect.Make_internal(RConf_int64) [@alert "-internal"]
+module RT_int64'_effect = Lin_effect.Make_internal(RConf_int64') [@alert "-internal"]
 
 module CLConf_int' =
 struct
@@ -47,8 +47,8 @@ struct
     | Add_node i -> RAdd_node (try Lin_effect.yield (); Ok (CList.add_node r i) with exn -> Error exn)
     | Member i   -> RMember (CList.member r i)
 end
-module CLT_int_effect = Lin_effect.Make_internal(CLConf (Int))
-module CLT_int'_effect = Lin_effect.Make_internal(CLConf_int')
+module CLT_int_effect = Lin_effect.Make_internal(CLConf (Int)) [@alert "-internal"]
+module CLT_int'_effect = Lin_effect.Make_internal(CLConf_int') [@alert "-internal"]
 
 module CLConf_int64' =
 struct
@@ -58,8 +58,8 @@ struct
     | Add_node i -> RAdd_node (try Lin_effect.yield (); Ok (CList.add_node r i) with exn -> Error exn)
     | Member i   -> RMember (CList.member r i)
 end
-module CLT_int64_effect = Lin_effect.Make_internal(CLConf(Int64))
-module CLT_int64'_effect = Lin_effect.Make_internal(CLConf_int64')
+module CLT_int64_effect = Lin_effect.Make_internal(CLConf(Int64)) [@alert "-internal"]
+module CLT_int64'_effect = Lin_effect.Make_internal(CLConf_int64') [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 20_000 in [

--- a/src/neg_tests/lin_tests_thread_conclist.ml
+++ b/src/neg_tests/lin_tests_thread_conclist.ml
@@ -2,8 +2,8 @@ open Lin_tests_common
 
 (** This is a driver of the negative CList tests over the Thread module *)
 
-module CLT_int_thread = Lin_thread.Make_internal(CLConf (Int))
-module CLT_int64_thread = Lin_thread.Make_internal(CLConf (Int64))
+module CLT_int_thread = Lin_thread.Make_internal(CLConf (Int)) [@alert "-internal"]
+module CLT_int64_thread = Lin_thread.Make_internal(CLConf (Int64)) [@alert "-internal"]
 
 ;;
 QCheck_base_runner.run_tests_main

--- a/src/neg_tests/lin_tests_thread_ref.ml
+++ b/src/neg_tests/lin_tests_thread_ref.ml
@@ -2,8 +2,8 @@ open Lin_tests_common
 
 (** This is a driver of the negative ref tests over the Thread module *)
 
-module RT_int_thread = Lin_thread.Make_internal(RConf_int)
-module RT_int64_thread = Lin_thread.Make_internal(RConf_int64)
+module RT_int_thread = Lin_thread.Make_internal(RConf_int) [@alert "-internal"]
+module RT_int64_thread = Lin_thread.Make_internal(RConf_int64) [@alert "-internal"]
 
 ;;
 if Sys.backend_type = Sys.Bytecode

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -105,10 +105,10 @@ module QMutexConf =
                        RClear
 end
 
-module QMT_domain = Lin_domain.Make_internal(QMutexConf)
-module QMT_thread = Lin_thread.Make_internal(QMutexConf)
-module QT_domain  = Lin_domain.Make_internal(QConf)
-module QT_thread  = Lin_thread.Make_internal(QConf)
+module QMT_domain = Lin_domain.Make_internal(QMutexConf) [@alert "-internal"]
+module QMT_thread = Lin_thread.Make_internal(QMutexConf) [@alert "-internal"]
+module QT_domain  = Lin_domain.Make_internal(QConf) [@alert "-internal"]
+module QT_thread  = Lin_thread.Make_internal(QConf) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main [
     QMT_domain.lin_test    ~count:1000 ~name:"Lin Queue test with Domain and mutex";

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -1,5 +1,5 @@
 open QCheck
-open Lin.Internal
+open Lin.Internal [@@alert "-internal"]
 
 module Spec =
   struct

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -1,5 +1,5 @@
 open QCheck
-open Lin.Internal
+open Lin.Internal [@@alert "-internal"]
 
 module Spec =
   struct

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -105,10 +105,10 @@ module SMutexConf =
                        RLength l
   end
 
-module ST_domain = Lin_domain.Make_internal(SConf)
-module ST_thread = Lin_thread.Make_internal(SConf)
-module SMT_domain = Lin_domain.Make_internal(SMutexConf)
-module SMT_thread = Lin_thread.Make_internal(SMutexConf)
+module ST_domain = Lin_domain.Make_internal(SConf) [@alert "-internal"]
+module ST_thread = Lin_thread.Make_internal(SConf) [@alert "-internal"]
+module SMT_domain = Lin_domain.Make_internal(SMutexConf) [@alert "-internal"]
+module SMT_thread = Lin_thread.Make_internal(SMutexConf) [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main [
     SMT_domain.lin_test    ~count:1000 ~name:"Lin Stack test with Domain and mutex";


### PR DESCRIPTION
To address half of #192, set up alerts on uses of the `internal` modules and explicitly disable them on expected sites in `lib`.
This PR is split in various commits so that the alerts do show up before being disabled.