### PR TITLE
Add a print_vertical function

### DIFF
--- a/doc/stm/index.mld
+++ b/doc/stm/index.mld
@@ -233,15 +233,17 @@ And the test fails...
 
 {[
 $ dune exec ./mutable_set.exe
-random seed: 445566802
+random seed: 499586059
 generated error fail pass / total     time test name
 [✗]    2    0    1    1 /  100     0.0s STM sequential tests
 
 --- Failure --------------------------------------------------------------------
 
-Test STM sequential tests failed (11 shrink steps):
+Test STM sequential tests failed (3 shrink steps):
 
-[(Add -1397066193181869250); Cardinal]
+   (Add 4231961964031379412)
+   Cardinal
+
 
 +++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -249,7 +251,7 @@ Messages for test STM sequential tests:
 
   Results incompatible with model
 
-   (Add -1397066193181869250) : ()
+   (Add 4231961964031379412) : ()
    Cardinal : 0
 ================================================================================
 failure (1 tests failed, 0 tests errored, ran 1 tests)
@@ -258,8 +260,8 @@ failure (1 tests failed, 0 tests errored, ran 1 tests)
 In the case of a failing test, [qcheck-stm] gives the user the counter example
 it has found, after some shrinking steps, as it is customary in property-based
 testing {i à la} QuickCheck. The counter example is a program. It is given
-twice: the first time just as a list of calls; the second time, each call is
-paired with the result of the computation.
+twice: the first time just as a sequence of calls; the second time, each call
+is paired with the result of the computation.
 
 Looking at the output, we see that [Add 3591134320860609976] returns a [unit],
 which is to be expected. But the call to [Cardinal] returns [0] despite the fact
@@ -551,15 +553,19 @@ This will be enough to trigger a failure in the test which can help us correct
 our implementation.
 
 {[
-random seed: 77853703
+$ dune exec ./mutable_set.exe
+random seed: 185490690
 generated error fail pass / total     time test name
 [✗]    1    0    1    0 /  100     0.0s STM sequential tests
 
 --- Failure --------------------------------------------------------------------
 
-Test STM sequential tests failed (15 shrink steps):
+Test STM sequential tests failed (9 shrink steps):
 
-[(Add -4159291639600813199); (Remove -4159291639600813199); Cardinal; (Remove 1369714189526732393)]
+   (Add -410825599021310838)
+   (Remove -410825599021310838)
+   Cardinal
+
 
 +++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -567,8 +573,8 @@ Messages for test STM sequential tests:
 
   Results incompatible with model
 
-   (Add -4159291639600813199) : ()
-   (Remove -4159291639600813199) : Some (-4159291639600813199)
+   (Add -410825599021310838) : ()
+   (Remove -410825599021310838) : Some (-410825599021310838)
    Cardinal : 1
 ================================================================================
 failure (1 tests failed, 0 tests errored, ran 1 tests)

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -138,7 +138,7 @@ struct
       let ac = QCheck.make ~shrink:(Shrink.filter (cmds_ok Spec.init_state) shrinker) cmds_gen in
       (match (Spec.arb_cmd s).print with
        | None   -> ac
-       | Some p -> set_print (Print.list p) ac)
+       | Some p -> set_print (Util.print_vertical p) ac)
 
     let consistency_test ~count ~name =
       Test.make ~name ~count (arb_cmds Spec.init_state) (cmds_ok Spec.init_state)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -29,6 +29,14 @@ let fork_prop_with_timeout sec p x =
      | WSIGNALED _
      | WSTOPPED _  -> false)
 
+let print_vertical ?(fig_indent=3) show cmds =
+  let cmds = List.map show cmds in
+  let buf = Buffer.create 64 in
+  let indent () = Printf.bprintf buf "%s" (String.make fig_indent ' ') in
+  let print_seq_col c = Printf.bprintf buf "%s\n" c in
+  let () = List.iter (fun c -> indent (); print_seq_col c) cmds in
+  Buffer.contents buf
+
 let print_triple_vertical ?(fig_indent=10) ?(res_width=20) ?(center_prefix=true) show (seq,cmds1,cmds2) =
   let seq,cmds1,cmds2 = List.(map show seq, map show cmds1, map show cmds2) in
   let max_width ss = List.fold_left max 0 (List.map String.length ss) in

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -20,6 +20,11 @@ val fork_prop_with_timeout : int -> ('a -> bool) -> 'a -> bool
     times out and raises [Timeout] after [s] seconds, like [prop_timeout s prop].
     This is handy if the tested code can segfault or loop infinitely. *)
 
+val print_vertical : ?fig_indent:int -> ('a -> string) -> 'a list -> string
+(** [print_vertical pr cmds] returns a string representing a sequential trace.
+    Optional [fig_indent] indicates how many spaces it should be indented (default: 3 spaces).
+ *)
+
 val print_triple_vertical :
   ?fig_indent:int ->
   ?res_width:int ->


### PR DESCRIPTION
Sequential trace for STM tests were printed as a list, which is inconstistent with the failure message printed just below them.

This commit proposes a print_vertical function on the model of print_triple_vertical. This is the reason why the new function is placed in the Util module, despite the fact that it is only used by STM.

Fix #218 