### PR TITLE
CI: Ensure at most one simultaneous run per PR

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,5 +1,9 @@
 name: Common CI workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,9 @@
 name: Windows mingw64 common workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Updating a PR will cancel all the current runs
We still keep the runs on standard push, by using `head_ref` which is defined only on PR events or falling back on `run_id` which is unique otherwise

Closes #225.