### PR TITLE
Use QCheck_base_runner in doc documentation

### DIFF
--- a/doc/lin/dune
+++ b/doc/lin/dune
@@ -5,9 +5,9 @@
 (executable
   (name mutable_set)
   (modules mutable_set)
-  (libraries qcheck qcheck-lin.domain))
+  (libraries qcheck-lin.domain))
 
 (executable
   (name mutable_set_lock)
   (modules mutable_set_lock)
-  (libraries qcheck qcheck-lin.domain))
+  (libraries qcheck-lin.domain))

--- a/doc/lin/index.mld
+++ b/doc/lin/index.mld
@@ -162,7 +162,7 @@ Here, we expect the test to succeed, so we will use the first one.
 module LibDomain = Lin_domain.Make (Spec)
 
 let _ =
-  QCheck_runner.run_tests ~verbose:true
+  QCheck_base_runner.run_tests ~verbose:true
     [ LibDomain.lin_test ~count:1000 ~name:"Lin parallel tests" ]
 ]}
 

--- a/doc/lin/index.mld
+++ b/doc/lin/index.mld
@@ -292,7 +292,7 @@ Once this is done, we can use exactly the same specification and tests. The
 successful output looks like the following:
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_lock.exe
 random seed: 162610433
 generated error fail pass / total     time test name
 [✓] 1000    0    0 1000 / 1000    48.0s Lin parallel tests

--- a/doc/lin/mutable_set.ml
+++ b/doc/lin/mutable_set.ml
@@ -59,5 +59,5 @@ end
 module LibDomain = Lin_domain.Make (Spec)
 
 let _ =
-  QCheck_runner.run_tests ~verbose:true
+  QCheck_base_runner.run_tests ~verbose:true
     [ LibDomain.lin_test ~count:1000 ~name:"Lin parallel tests" ]

--- a/doc/lin/mutable_set_lock.ml
+++ b/doc/lin/mutable_set_lock.ml
@@ -74,5 +74,5 @@ end
 module LibDomain = Lin_domain.Make (Spec)
 
 let _ =
-  QCheck_runner.run_tests ~verbose:true
+  QCheck_base_runner.run_tests ~verbose:true
     [ LibDomain.lin_test ~count:1000 ~name:"Lin parallel tests" ]

--- a/doc/stm/dune
+++ b/doc/stm/dune
@@ -5,29 +5,29 @@
 (executable
   (name mutable_set_v0)
   (modules mutable_set_v0)
-  (libraries qcheck qcheck-stm.sequential)
+  (libraries qcheck-stm.sequential)
   (preprocess (pps ppx_deriving.show)))
 
 (executable
   (name mutable_set_v1)
   (modules mutable_set_v1)
-  (libraries qcheck qcheck-stm.sequential)
+  (libraries qcheck-stm.sequential)
   (preprocess (pps ppx_deriving.show)))
 
 (executable
   (name mutable_set_v2)
   (modules mutable_set_v2)
-  (libraries qcheck qcheck-stm.domain)
+  (libraries qcheck-stm.domain)
   (preprocess (pps ppx_deriving.show)))
 
 (executable
   (name mutable_set_v3)
   (modules mutable_set_v3)
-  (libraries qcheck qcheck-stm.domain)
+  (libraries qcheck-stm.domain)
   (preprocess (pps ppx_deriving.show)))
 
 (executable
   (name mutable_set_v4)
   (modules mutable_set_v4)
-  (libraries qcheck qcheck-stm.sequential)
+  (libraries qcheck-stm.sequential)
   (preprocess (pps ppx_deriving.show)))

--- a/doc/stm/dune
+++ b/doc/stm/dune
@@ -31,3 +31,9 @@
   (modules mutable_set_v4)
   (libraries qcheck-stm.sequential)
   (preprocess (pps ppx_deriving.show)))
+
+(executable
+  (name mutable_set_v5)
+  (modules mutable_set_v5)
+  (libraries qcheck-stm.sequential)
+  (preprocess (pps ppx_deriving.show)))

--- a/doc/stm/index.mld
+++ b/doc/stm/index.mld
@@ -232,7 +232,7 @@ let _ =
 And the test fails...
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_v0.exe
 random seed: 499586059
 generated error fail pass / total     time test name
 [✗]    2    0    1    1 /  100     0.0s STM sequential tests
@@ -288,7 +288,7 @@ end
 When rerunning the sequential test, the output looks like that:
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_v1.exe
 random seed: 296715191
 generated error fail pass / total     time test name
 [✓]  100    0    0  100 /  100     1.2s STM sequential tests
@@ -333,7 +333,7 @@ let _ =
 And we are set to run the tests:
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_v2.exe
 random seed: 111516437
 generated error fail pass / total     time test name
 [✗]    3    0    1    2 /  100     0.8s STM parallel tests
@@ -429,10 +429,10 @@ change the signature of the function we want to test, the specification is
 exactly the same. So we can directly run the test.
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_v3.exe
 random seed: 99077635
 generated error fail pass / total     time test name
-[✓]  100    0    0  100 /  100    94.7s STM sequential tests
+[✓]  100    0    0  100 /  100    94.7s STM parallel tests
 ================================================================================
 success (ran 1 tests)
 ]}
@@ -513,7 +513,7 @@ Then, if we make the same mistake as above for the [add] function, namely:
 most of the time, [qcheck-stm] won't be able to spot the bug:
 
 {[
-$ dune exec ./stm-doc/mutable_set_v4.exe
+$ dune exec ./mutable_set_v4.exe
 random seed: 423411827
 generated error fail pass / total     time test name
 [✓]  100    0    0  100 /  100     0.8s STM sequential tests
@@ -553,7 +553,7 @@ This will be enough to trigger a failure in the test which can help us correct
 our implementation.
 
 {[
-$ dune exec ./mutable_set.exe
+$ dune exec ./mutable_set_v5.exe
 random seed: 185490690
 generated error fail pass / total     time test name
 [✗]    1    0    1    0 /  100     0.0s STM sequential tests

--- a/doc/stm/index.mld
+++ b/doc/stm/index.mld
@@ -225,7 +225,7 @@ Here, we expect the test to succeed, so we will use the first one.
 module Lib_sequential = STM_sequential.Make (Lib_spec)
 
 let _ =
-  QCheck_runner.run_tests ~verbose:true
+  QCheck_base_runner.run_tests ~verbose:true
     [ Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests" ]
 ]}
 
@@ -326,7 +326,7 @@ Here again, we expect the test to succeed, so we'll use the first one.
 module Lib_domain = STM_domain.Make (Lib_spec)
 
 let _ =
-  QCheck_runner.run_tests ~verbose:true
+  QCheck_base_runner.run_tests ~verbose:true
     [ Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests" ]
 ]}
 

--- a/doc/stm/mutable_set_v0.ml
+++ b/doc/stm/mutable_set_v0.ml
@@ -84,4 +84,6 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]

--- a/doc/stm/mutable_set_v0.ml
+++ b/doc/stm/mutable_set_v0.ml
@@ -84,4 +84,4 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]

--- a/doc/stm/mutable_set_v1.ml
+++ b/doc/stm/mutable_set_v1.ml
@@ -87,5 +87,5 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
 

--- a/doc/stm/mutable_set_v1.ml
+++ b/doc/stm/mutable_set_v1.ml
@@ -87,5 +87,7 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
 

--- a/doc/stm/mutable_set_v2.ml
+++ b/doc/stm/mutable_set_v2.ml
@@ -87,4 +87,6 @@ end
 
 module Lib_domain = STM_domain.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]

--- a/doc/stm/mutable_set_v2.ml
+++ b/doc/stm/mutable_set_v2.ml
@@ -87,4 +87,4 @@ end
 
 module Lib_domain = STM_domain.Make(Lib_spec)
 
-let _ = QCheck_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]
+let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]

--- a/doc/stm/mutable_set_v3.ml
+++ b/doc/stm/mutable_set_v3.ml
@@ -100,5 +100,7 @@ end
 
 module Lib_domain = STM_domain.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_domain.agree_test_par ~count:100 ~name:"STM parallel tests"]
 

--- a/doc/stm/mutable_set_v3.ml
+++ b/doc/stm/mutable_set_v3.ml
@@ -100,5 +100,5 @@ end
 
 module Lib_domain = STM_domain.Make(Lib_spec)
 
-let _ = QCheck_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM sequential tests"]
+let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_domain.agree_test_par ~count:100 ~name:"STM sequential tests"]
 

--- a/doc/stm/mutable_set_v4.ml
+++ b/doc/stm/mutable_set_v4.ml
@@ -121,5 +121,7 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
 

--- a/doc/stm/mutable_set_v4.ml
+++ b/doc/stm/mutable_set_v4.ml
@@ -109,18 +109,13 @@ module Lib_spec : Spec = struct
     | Remove i, Res ((Option Int, _), None)   -> not (List.mem i state)
     | _                                       -> false
 
-  let arb_cmd state =
-    let gen =
-      match state with
-      | [] -> Gen.int
-      | xs -> Gen.(oneof [oneofl xs; int])
-    in
+  let arb_cmd _state =
     QCheck.make ~print:show_cmd
       (QCheck.Gen.oneof
         [Gen.return Cardinal;
-         Gen.map (fun i -> Mem i) gen;
-         Gen.map (fun i -> Add i) gen;
-         Gen.map (fun i -> Remove i) gen;
+         Gen.map (fun i -> Mem i) Gen.int;
+         Gen.map (fun i -> Add i) Gen.int;
+         Gen.map (fun i -> Remove i) Gen.int;
         ])
 end
 

--- a/doc/stm/mutable_set_v4.ml
+++ b/doc/stm/mutable_set_v4.ml
@@ -126,5 +126,5 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
 

--- a/doc/stm/mutable_set_v5.ml
+++ b/doc/stm/mutable_set_v5.ml
@@ -126,5 +126,7 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests ~verbose:true [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
+let _ =
+  QCheck_base_runner.run_tests ~verbose:true
+    [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]
 


### PR DESCRIPTION
This PR fixes #228

Besides updating the examples and the `index.mld` files it also irons out a few things I spotted underway
- adding a missing stm example
- correcting a wrong stm test title
- breaking very long lines
- using the names of the provided test examples consistently