### PR TITLE
Adjust STM cmd list shrinker

### DIFF
--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -293,15 +293,15 @@ struct
            (* Shrinking heuristic:
               First reduce the cmd list sizes as much as possible, since the interleaving
               is most costly over long cmd lists. *)
-           (map (fun seq' -> (seq',p1,p2)) (Shrink.list_spine seq))
+           (map (fun seq' -> (seq',p1,p2)) (shrink_list_spine seq))
            <+>
            (match p1 with [] -> Iter.empty | c1::c1s -> Iter.return (seq@[c1],c1s,p2))
            <+>
            (match p2 with [] -> Iter.empty | c2::c2s -> Iter.return (seq@[c2],p1,c2s))
            <+>
-           (map (fun p1' -> (seq,p1',p2)) (Shrink.list_spine p1))
+           (map (fun p1' -> (seq,p1',p2)) (shrink_list_spine p1))
            <+>
-           (map (fun p2' -> (seq,p1,p2')) (Shrink.list_spine p2))
+           (map (fun p2' -> (seq,p1,p2')) (shrink_list_spine p2))
            <+>
            (* Secondly reduce the cmd data of individual list elements *)
            (shrink_triple_elems arb0 arb1 arb2 triple))

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -295,9 +295,9 @@ struct
               is most costly over long cmd lists. *)
            (map (fun seq' -> (seq',p1,p2)) (shrink_list_spine seq))
            <+>
-           (match p1 with [] -> Iter.empty | c1::c1s -> Iter.return (seq@[c1],c1s,p2))
+           (fun yield -> (match p1 with [] -> Iter.empty | c1::c1s -> Iter.return (seq@[c1],c1s,p2)) yield)
            <+>
-           (match p2 with [] -> Iter.empty | c2::c2s -> Iter.return (seq@[c2],p1,c2s))
+           (fun yield -> (match p2 with [] -> Iter.empty | c2::c2s -> Iter.return (seq@[c2],p1,c2s)) yield)
            <+>
            (map (fun p1' -> (seq,p1',p2)) (shrink_list_spine p1))
            <+>

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -4,7 +4,7 @@
 (alias
  (name default)
  (package multicoretests)
- (deps cleanup.exe util_print_test.exe))
+ (deps cleanup.exe util_print_test.exe mutable_set_v5.exe))
 
 (test
  (name util_print_test)
@@ -20,3 +20,13 @@
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
  (action (run ./%{test} --verbose)))
+
+
+(test
+ (name mutable_set_v5)
+ (modules mutable_set_v5)
+ (package multicoretests)
+ (libraries qcheck-stm.sequential)
+ (preprocess (pps ppx_deriving.show))
+ (action
+  (with-accepted-exit-codes 1 (run ./%{test} --verbose --seed 229109553))))

--- a/src/internal/mutable_set_v5.expected
+++ b/src/internal/mutable_set_v5.expected
@@ -1,20 +1,17 @@
-random seed: 229109553
+[2Krandom seed: 229109553
 generated error fail pass / total     time test name
-[ ]    0    0    0    0 /  100     0.0s STM sequential tests
-[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)
-[✗]    2    0    1    1 /  100     0.0s STM sequential tests
+[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)[2K[[31;1m✗[0m]    2    0    1    1 /  100     0.0s STM sequential tests
 
---- Failure --------------------------------------------------------------------
+--- [31;1mFailure[0m --------------------------------------------------------------------
 
 Test STM sequential tests failed (15 shrink steps):
 
    (Add -3922091896265746428)
    (Remove -3922091896265746428)
    Cardinal
-   Cardinal
 
 
-+++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++++ [34;1mMessages[0m ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Messages for test STM sequential tests:
 
@@ -24,4 +21,4 @@ Messages for test STM sequential tests:
    (Remove -3922091896265746428) : Some (-3922091896265746428)
    Cardinal : 1
 ================================================================================
-failure (1 tests failed, 0 tests errored, ran 1 tests)
+[31;1mfailure[0m (1 tests failed, 0 tests errored, ran 1 tests)

--- a/src/internal/mutable_set_v5.expected
+++ b/src/internal/mutable_set_v5.expected
@@ -1,0 +1,27 @@
+random seed: 229109553
+generated error fail pass / total     time test name
+[ ]    0    0    0    0 /  100     0.0s STM sequential tests
+[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)
+[✗]    2    0    1    1 /  100     0.0s STM sequential tests
+
+--- Failure --------------------------------------------------------------------
+
+Test STM sequential tests failed (15 shrink steps):
+
+   (Add -3922091896265746428)
+   (Remove -3922091896265746428)
+   Cardinal
+   Cardinal
+
+
++++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Messages for test STM sequential tests:
+
+  Results incompatible with model
+
+   (Add -3922091896265746428) : ()
+   (Remove -3922091896265746428) : Some (-3922091896265746428)
+   Cardinal : 1
+================================================================================
+failure (1 tests failed, 0 tests errored, ran 1 tests)

--- a/src/internal/mutable_set_v5.ml
+++ b/src/internal/mutable_set_v5.ml
@@ -1,0 +1,130 @@
+module type S = sig
+  type elt
+  type t
+  val empty    : unit -> t
+  val mem      : elt -> t -> bool
+  val add      : elt -> t -> unit
+  val cardinal : t -> int
+  val remove   : elt -> t -> elt option
+end
+
+module Lib : sig
+  module Make : functor (Ord : Set.OrderedType) -> S with type elt = Ord.t
+end
+= struct
+  module Make (Ord : Set.OrderedType) =
+    struct
+    module S = Set.Make (Ord)
+
+    type elt = Ord.t
+
+    type t = {
+      mutable content  : S.t;
+      mutable cardinal : int;
+      mutex            : Mutex.t}
+
+    let empty () = { content = S.empty; cardinal = 0; mutex = Mutex.create () }
+
+    let mem_non_lock a t = S.mem a t.content
+
+    let mem a t =
+      Mutex.lock t.mutex;
+      let b = mem_non_lock a t in
+      Mutex.unlock t.mutex;
+      b
+
+    let add a t =
+      Mutex.lock t.mutex;
+      if not (mem_non_lock a t)
+      then begin
+        t.content <- S.add a t.content;
+        t.cardinal <- t.cardinal + 1;
+      end;
+      Mutex.unlock t.mutex
+
+    let cardinal t =
+      Mutex.lock t.mutex;
+      let c = t.cardinal in
+      Mutex.unlock t.mutex;
+      c
+
+    let remove a t =
+      Mutex.lock t.mutex;
+      let r =
+        if mem_non_lock a t
+        then begin
+          t.content  <- S.remove a t.content;
+          (* t.cardinal <- t.cardinal - 1; *)
+          Some a
+        end
+        else None
+      in
+      Mutex.unlock t.mutex;
+      r
+  end
+end
+
+open QCheck
+open STM
+
+module Lib_spec : Spec = struct
+
+  module S = Lib.Make (Int)
+
+  type sut = S.t
+  let init_sut () = S.empty ()
+  let cleanup _ = ()
+
+  type cmd =
+    | Mem of int
+    | Add of int
+    | Cardinal
+    | Remove of int [@@deriving show { with_path = false }]
+
+  let run cmd sut =
+    match cmd with
+    | Mem i    -> Res (bool, S.mem i sut)
+    | Add i    -> Res (unit, S.add i sut)
+    | Cardinal -> Res (int, S.cardinal sut)
+    | Remove i -> Res (option int, S.remove i sut)
+
+  type state = int list
+  let init_state = []
+
+  let next_state cmd state =
+    match cmd with
+    | Mem _    -> state
+    | Add i    -> if List.mem i state then state else i :: state
+    | Cardinal -> state
+    | Remove i -> if List.mem i state then List.filter (fun x -> x <> i) state else state
+
+  let precond _cmd _state = true
+
+  let postcond cmd state res =
+    match cmd, res with
+    | Mem i,  Res ((Bool,_), b)               -> b = List.mem i state
+    | Cardinal, Res ((Int,_), l)              -> l = List.length state
+    | Add _,  Res ((Unit,_),_)                -> true
+    | Remove i, Res ((Option Int, _), Some x) -> List.mem i state && i = x
+    | Remove i, Res ((Option Int, _), None)   -> not (List.mem i state)
+    | _                                       -> false
+
+  let arb_cmd state =
+    let gen =
+      match state with
+      | [] -> Gen.int
+      | xs -> Gen.(oneof [oneofl xs; int])
+    in
+    QCheck.make ~print:show_cmd
+      (QCheck.Gen.oneof
+        [Gen.return Cardinal;
+         Gen.map (fun i -> Mem i) gen;
+         Gen.map (fun i -> Add i) gen;
+         Gen.map (fun i -> Remove i) gen;
+        ])
+end
+
+module Lib_sequential = STM_sequential.Make(Lib_spec)
+
+let _ = QCheck_base_runner.run_tests_main
+    [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]


### PR DESCRIPTION
This fixes #217 

The problem is caused by the underlying QCheck list shrinker, which cannot be both computationally fast (in the big-O sense) and complete/exhaustive. The four-element list example is bitten by this.

The PR fixes the problem by stopping the recursion a bit earlier and producing more desirable candidates for the new 3- and 4-element base cases without ruining the computational complexity (see plot below).

In addition the PR includes a few clean-ups
- to rename shrinker functions to slightly more saying names
- to eta-expand and potentially save a bit of time on a list concatenation

----

I compared the plot of the following little routine
```ocaml
let rec loop n acc = match n with
  | 0 -> ()
  | _ ->
    Printf.printf "%3i: %!" (List.length acc);
    shrink_list_spine acc (fun xs -> Printf.printf "#%!");
    Printf.printf "\n%!";
    loop (n-1) (n::acc)
```
which has identical "logarithmic shaped" output for both `shrink_list_spine` and `QCheck.Shrink.list_spine`:
```
# loop 30 [];;
  0: 
  1: #
  2: ###
  3: ####
  4: ####
  5: #####
  6: #####
  7: #####
  8: #####
  9: ######
 10: ######
 11: ######
 12: ######
 13: ######
 14: ######
 15: ######
 16: ######
 17: #######
 18: #######
 19: #######
 20: #######
 21: #######
 22: #######
 23: #######
 24: #######
 25: #######
 26: #######
 27: #######
 28: #######
 29: #######
```