### PR TITLE
Add some links in documentation

### DIFF
--- a/doc/stm/index.mld
+++ b/doc/stm/index.mld
@@ -9,7 +9,7 @@
 
 {1 Overview: what is [qcheck-stm]?}
 
-[qcheck-stm] is a model-based testing framework that builds upon [QCheck].
+[qcheck-stm] is a model-based testing framework that builds upon {!QCheck}.
 According to a library description, it generates random programs using the
 functionalities of this library and runs them, records the results at each step
 of the run, and compares these results with the behaviour of a given pure
@@ -33,7 +33,7 @@ of the run, and compares these results with the behaviour of a given pure
 {1 Example: how to test a library?}
 
 Suppose we want to implement a small mutable set library, our main focus being
-to have a constant time [cardinal] operation. We will be using [Stdlib.Set] for
+to have a constant time [cardinal] operation. We will be using {!Stdlib.Set} for
 the content, keeping track of the cardinality when adding and removing elements.
 
 Of course, we will be using [qcheck-stm] for testing!
@@ -52,7 +52,7 @@ module type S = sig
 end
 ]}
 
-This is obviously a subset of [Set.S]. The first version of the implementation
+This is obviously a subset of {{!Stdlib.Set.S}[Set.S]}. The first version of the implementation
 looks like that:
 
 {[
@@ -173,7 +173,7 @@ and [sut] and wraps the result with information about its type in a
 {3 The model definition}
 
 [state] is the type of the model. The model should be pure and simple enough to
-be obviously correct. Here we use a simple {{!Stdlib.List}list} from the
+be obviously correct. Here we use a simple {{!Stdlib.List.t}[list]} from the
 standard library.
 
 [qcheck-stm] also needs to know what is the model's initial value. This is
@@ -199,7 +199,7 @@ function to our set library.
 
 The last thing to do is to tell [qcheck-stm] how to generate the [cmd]s. This
 is what is done by the [arb_cmd] function, using [QCheck]'s combinators. We
-will make two remarks on this function.  The first one is that [QCheck.make]
+will make two remarks on this function.  The first one is that {!QCheck.make}
 takes an optional printer. It is important to provide it so that the test's
 output is printed. Here we use the function [show_cmd] that has been built by
 ppx_deriver from [cmd]'s definition.  The second remark is that [arb_cmd] takes
@@ -373,7 +373,7 @@ safe to be used in parallel.
 
 We can see that the output is a bit different than the one with the failing
 sequential test. This is because the generated programs are a bit different
-too. For testing with using [Domain], [qcheck-stm] generates a triplet of list
+too. For testing with using {!Stdlib.Domain}, [qcheck-stm] generates a triplet of lists
 of calls: one sequential prefix to bring the system under test in a random
 state and two parallel suffixes.
 

--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -194,4 +194,4 @@ end
 
 
 val protect : ('a -> 'b) -> 'a -> ('b, exn) result
-(** [protect f] turns an [exception] throwing function into a {{!Stdlib.Result.t}[result]} returning function. *)
+(** [protect f] turns an [exception]-throwing function into a {{!Stdlib.Result.t}[result]}-returning function. *)

--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -25,49 +25,49 @@ type 'a ty_show = 'a ty * ('a -> string)
 (** Combinator type to represent an OCaml type along with an associated [to_string] function *)
 
 val unit : unit ty_show
-(** Combinator to represent the [unit] type *)
+(** Combinator to represent the {{!Stdlib.Unit.t}[unit]} type *)
 
 val bool : bool ty_show
-(** Combinator to represent the [bool] type *)
+(** Combinator to represent the {{!Stdlib.Bool.t}[bool]} type *)
 
 val char : char ty_show
-(** Combinator to represent the [char] type *)
+(** Combinator to represent the {{!Stdlib.Char.t}[char]} type *)
 
 val int : int ty_show
-(** Combinator to represent the [int] type *)
+(** Combinator to represent the {{!Stdlib.Int.t}[int]} type *)
 
 val int32 : int32 ty_show
-(** Combinator to represent the [int32] type *)
+(** Combinator to represent the {{!Stdlib.Int32.t}[int32]} type *)
 
 val int64 : int64 ty_show
-(** Combinator to represent the [int64] type *)
+(** Combinator to represent the {{!Stdlib.Int64.t}[int64]} type *)
 
 val float : float ty_show
-(** Combinator to represent the [float] type *)
+(** Combinator to represent the {{!Stdlib.Float.t}[float]} type *)
 
 val string : string ty_show
-(** Combinator to represent the [string] type *)
+(** Combinator to represent the {{!Stdlib.String.t}[string]} type *)
 
 val bytes : bytes ty_show
-(** Combinator to represent the [bytes] type *)
+(** Combinator to represent the {{!Stdlib.Bytes.t}[bytes]} type *)
 
 val option : 'a ty_show -> 'a option ty_show
-(** [option t] builds a [t option] type representation *)
+(** [option t] builds a [t] {{!Stdlib.Option.t}[option]} type representation *)
 
 val exn : exn ty_show
 (** Combinator to represent the [exception] type *)
 
 val result : 'a ty_show -> 'b ty_show -> ('a,'b) Result.t ty_show
-(** [result a b] builds an [(a,b) Result.t] type representation *)
+(** [result a b] builds an [(a,b)] {{!Stdlib.Result.t}[result]} type representation *)
 
 val list : 'a ty_show -> 'a list ty_show
-(** [list t] builds a [t list] type representation *)
+(** [list t] builds a [t] {{!Stdlib.List.t}[list]} type representation *)
 
 val array : 'a ty_show -> 'a array ty_show
-(** [array t] builds a [t array] type representation *)
+(** [array t] builds a [t] {{!Stdlib.Array.t}[array]} type representation *)
 
 val seq : 'a ty_show -> 'a Seq.t ty_show
-(** [seq t] builds a [t Seq.t] type representation *)
+(** [seq t] builds a [t] {{!Stdlib.Seq.t}[Seq.t]} type representation *)
 
 type res =
   Res : 'a ty_show * 'a -> res
@@ -88,7 +88,7 @@ sig
   (** The type of the system under test *)
 
   val arb_cmd : state -> cmd QCheck.arbitrary
-  (** A command generator. Accepts a state parameter to enable state-dependent [cmd] generation. *)
+  (** A command generator. Accepts a state parameter to enable state-dependent {!cmd} generation. *)
 
   val init_state : state
   (** The model's initial state. *)
@@ -105,7 +105,7 @@ sig
   (** Initialize the system under test. *)
 
   val cleanup : sut -> unit
-  (** Utility function to clean up the [sut] after each test instance,
+  (** Utility function to clean up the {!sut} after each test instance,
       e.g., for closing sockets, files, or resetting global parameters*)
 
   val precond : cmd -> state -> bool
@@ -119,7 +119,7 @@ sig
 
   val postcond : cmd -> state -> res -> bool
   (** [postcond c s res] checks whether [res] arising from interpreting the
-      command [c] over the system under test with [run] agrees with the
+      command [c] over the system under test with {!run} agrees with the
       model's result. A [postcond] function should be a pure.
 
       {b Note:} the state parameter [s] is the model's {!state} before executing the command [c] (the "old/pre" state).
@@ -176,11 +176,11 @@ sig
 
     val all_interleavings_ok : Spec.cmd list -> Spec.cmd list -> Spec.cmd list -> Spec.state -> bool
     (** [all_interleavings_ok seq spawn0 spawn1 state] checks that
-        preconditions of all the [cmd]s of [seq], [spawn0], and [spawn1] are satisfied in all the
+        preconditions of all the {!cmd}s of [seq], [spawn0], and [spawn1] are satisfied in all the
         possible interleavings and starting with [state] *)
 
     val shrink_triple : (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) Shrink.t
-    (** [shrink_triple arb0 arb1 arb2] is a [Shrinker.t] for programs (triple of list of [cmd]s) that is specialized for each part of the program. *)
+    (** [shrink_triple arb0 arb1 arb2] is a {!QCheck.Shrink.t} for programs (triple of list of [cmd]s) that is specialized for each part of the program. *)
 
     val arb_triple : int -> int -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.state -> Spec.cmd arbitrary) -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) arbitrary
     (** [arb_triple seq_len par_len arb0 arb1 arb2] generates a [cmd] triple with at most [seq_len]
@@ -194,4 +194,4 @@ end
 
 
 val protect : ('a -> 'b) -> 'a -> ('b, exn) result
-(** [protect f] turns an [exception] throwing function into a [result] returning function. *)
+(** [protect f] turns an [exception] throwing function into a {{!Stdlib.Result.t}[result]} returning function. *)

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -1,4 +1,4 @@
-(** Module for building parallel STM tests over [Domain]s *)
+(** Module for building parallel STM tests over {!Stdlib.Domain}s *)
 
 module Make : functor (Spec : STM.Spec) ->
   sig
@@ -9,21 +9,21 @@ module Make : functor (Spec : STM.Spec) ->
     val arb_triple : int -> int -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
     (** [arb_triple seq_len par_len arb0 arb1 arb2] generates a [cmd] triple with at most [seq_len]
         sequential commands and at most [par_len] parallel commands each.
-        The three [cmd] components are generated with [arb0], [arb1], and [arb2], respectively.
+        The three {!Spec.cmd} components are generated with [arb0], [arb1], and [arb2], respectively.
         Each of these take the model state as a parameter. *)
 
     val shrink_triple : (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.Shrink.t
-    (** [shrink_triple arb0 arb1 arb2] is a [Shrinker.t] for programs (triple of list of [cmd]s) that is specialized for each part of the program. *)
+    (** [shrink_triple arb0 arb1 arb2] is a {!QCheck.Shrink.t} for programs (triple of lists of {!Spec.cmd}s) that is specialized for each part of the program. *)
 
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * STM.res) list
-    (** [interp_sut_res sut cs] interprets the commands [cs] over the system [sut]
-        and returns the list of corresponding [cmd] and result pairs. *)
+    (** [interp_sut_res sut cs] interprets the commands [cs] over the system {!Spec.sut}
+        and returns the list of corresponding {!Spec.cmd} and result pairs. *)
 
     val agree_prop_par : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
-    (** Parallel agreement property based on [Domain] *)
+    (** Parallel agreement property based on {!Stdlib.Domain} *)
 
     val agree_test_par : count:int -> name:string -> QCheck.Test.t
-    (** Parallel agreement test based on [Domain] which combines [repeat] and [~retries] *)
+    (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries] *)
 
     val neg_agree_test_par : count:int -> name:string -> QCheck.Test.t
     (** A negative agreement test (for convenience). Accepts two labeled parameters:

--- a/lib/STM_sequential.mli
+++ b/lib/STM_sequential.mli
@@ -8,13 +8,13 @@ module Make : functor (Spec : STM.Spec) ->
 
     val gen_cmds_size : (Spec.state -> Spec.cmd QCheck.arbitrary) -> Spec.state -> int QCheck.Gen.t -> Spec.cmd list QCheck.Gen.t
     (** [gen_cmds_size arb state gen_int] generates a program of size generated
-        by [gen_int] using [arb] to generate [cmd]s according to the current
+        by [gen_int] using [arb] to generate {!Spec.cmd}s according to the current
         state. [state] is the starting state. *)
 
     val agree_prop : Spec.cmd list -> bool
     (** The agreement property: the command sequence [cs] yields the same observations
         when interpreted from the model's initial state and the [sut]'s initial state.
-        Cleans up after itself by calling [Spec.cleanup] *)
+        Cleans up after itself by calling {!Spec.cleanup}. *)
 
     val agree_test : count:int -> name:string -> QCheck.Test.t
     (** An actual agreement test (for convenience). Accepts two labeled parameters:

--- a/lib/STM_thread.mli
+++ b/lib/STM_thread.mli
@@ -1,4 +1,4 @@
-(** Module for building concurrent STM tests over [Thread]s *)
+(** Module for building concurrent STM tests over {!Thread}s *)
 
 module Make : functor (Spec : STM.Spec) ->
   sig
@@ -6,13 +6,13 @@ module Make : functor (Spec : STM.Spec) ->
 
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * STM.res) list
     (** [interp_sut_res sut cs] interprets the commands [cs] over the system [sut]
-        and returns the list of corresponding [cmd] and result pairs. *)
+        and returns the list of corresponding {!Spec.cmd} and result pairs. *)
 
     val agree_prop_conc : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
-    (** Concurrent agreement property based on [Thread] *)
+    (** Concurrent agreement property based on {!Thread} *)
 
     val agree_test_conc : count:int -> name:string -> QCheck.Test.t
-    (** Concurrent agreement test based on [Thread] which combines [repeat] and [~retries] *)
+    (** Concurrent agreement test based on {!Thread} which combines [repeat] and [~retries] *)
 
     val neg_agree_test_conc : count:int -> name:string -> QCheck.Test.t
     (** A negative agreement test (for convenience). Accepts two labeled parameters:

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -22,7 +22,7 @@ module Internal : sig
 
     val shrink_cmd : cmd QCheck.Shrink.t
     (** A command shrinker.
-        To a first approximation you can use [Shrink.nil]. *)
+        To a first approximation you can use {!QCheck.Shrink.nil}. *)
 
     type res
     (** The command result type *)
@@ -69,29 +69,29 @@ type deconstructible = |
 
 type combinable
 (** Type definition to denote that a described type can be composed with
-    other combinators such as [list]. *)
+    other combinators such as {!list}. *)
 
 type noncombinable
 (** Type definition to denote that a described type cannot be composed with
-    other combinators such as [list]. *)
+    other combinators such as {!list}. *)
 
 type (_, _, _, _) ty
 (** Type definition for type-describing combinators.
     [(typ,con,styp,comb) ty] represents a type [typ] and with an underlying state of type [styp].
-    The [con] type parameter indicates whether the combinator type is [constructible] or [deconstructible].
-    The [comb] type parameter indicates whether the combinator type is [combinable] or [noncombinable].
+    The [con] type parameter indicates whether the combinator type is {!constructible} or {!deconstructible}.
+    The [comb] type parameter indicates whether the combinator type is {!combinable} or {!noncombinable}.
 *)
 
 val gen : 'a QCheck.arbitrary -> ('a -> string) -> ('a, constructible, 's, combinable) ty
-(** [gen arb to_str] builds a [constructible] and [combinable] type combinator
+(** [gen arb to_str] builds a {!constructible} and {!combinable} type combinator
     from a QCheck generator [arb] and a to-string function [to_str]. *)
 
 val deconstructible : ('a -> string) -> ('a -> 'a -> bool) -> ('a, deconstructible, 's, combinable) ty
-(** [deconstructible to_str eq] builds a [deconstructible] and [combinable] type combinator
+(** [deconstructible to_str eq] builds a {!deconstructible} and {!combinable} type combinator
     from a to-string function [to_str] and an equality predicate [eq]. *)
 
 val gen_deconstructible : 'a QCheck.arbitrary -> ('a -> string) -> ('a -> 'a -> bool) -> ('a, 'c, 's, combinable) ty
-(** [gen_deconstructible arb to_str eq] builds a [combinable] type combinator
+(** [gen_deconstructible arb to_str eq] builds a {!combinable} type combinator
     from a QCheck generator [arb], a to-string function [to_str] and an
     equality predicate [eq]. *)
 
@@ -99,86 +99,86 @@ val gen_deconstructible : 'a QCheck.arbitrary -> ('a -> string) -> ('a -> 'a -> 
 (** {2 Type combinators} *)
 
 val unit : (unit, 'a, 'b, combinable) ty
-(** The [unit] combinator represents the [unit] type *)
+(** The [unit] combinator represents the {{!Stdlib.Unit.t}[unit]} type *)
 
 val bool : (bool, 'a, 'b, combinable) ty
-(** The [bool] combinator represents the [bool] type *)
+(** The [bool] combinator represents the {{!Stdlib.Bool.t}[bool]} type *)
 
 val char : (char, 'a, 'b, combinable) ty
-(** The [char] combinator represents the [char] type.
-    It uses a uniform generator based on [QCheck.char]. *)
+(** The [char] combinator represents the {{!Stdlib.Char.t}[char]} type.
+    It uses a uniform generator based on {!QCheck.char}. *)
 
 val char_printable : (char, 'a, 'b, combinable) ty
-(** The [char_printable] combinator represents the [char] type.
+(** The [char_printable] combinator represents the {{!Stdlib.Char.t}[char]} type.
     The generated characters have character codes 32-126 or 10 (newline)
-    and are based on [QCheck.printable_char]. *)
+    and are based on {!QCheck.printable_char}. *)
 
 val nat_small : (int, 'a, 'b, combinable) ty
-(** The [nat_small] combinator represents the [int] type.
+(** The [nat_small] combinator represents the {{!Stdlib.Int.t}[int]} type.
     The generated integers are non-negative, less than 100,
-    and are based on [QCheck.small_nat]. *)
+    and are based on {!QCheck.small_nat}. *)
 
 val int : (int, 'a, 'b, combinable) ty
-(** The [int] combinator represents the [int] type.
-    It uses a uniform generator based on [QCheck.int]. *)
+(** The [int] combinator represents the {{!Stdlib.Int.t}[int]} type.
+    It uses a uniform generator based on {!QCheck.int}. *)
 
 val int_small : (int, 'a, 'b, combinable) ty
-(** The [int_small] combinator represents the [int] type.
+(** The [int_small] combinator represents the {{!Stdlib.Int.t}[int]} type.
     The generated integers are non-negative
-    and are based on [QCheck.small_int]. *)
+    and are based on {!QCheck.small_int}. *)
 
 val int_pos : (int, 'a, 'b, combinable) ty
-(** The [int_pos] combinator represents the [int] type.
+(** The [int_pos] combinator represents the {{!Stdlib.Int.t}[int]} type.
     The generated integers are non-negative
-    and uniformly distributed. It is based on [QCheck.pos_int]. *)
+    and uniformly distributed. It is based on {!QCheck.pos_int}. *)
 
 val int_bound : int -> (int, 'a, 'b, combinable) ty
-(** The [int_bound b] combinator represents the [int] type.
+(** The [int_bound b] combinator represents the {{!Stdlib.Int.t}[int]} type.
     The generated integers range from [0] to [b], inclusive.
-    It uses a uniform generator based on [QCheck.int_bound]. *)
+    It uses a uniform generator based on {!QCheck.int_bound}. *)
 
 val int32 : (Int32.t, 'a, 'b, combinable) ty
-(** The [int32] combinator represents the [int32] type.
-    It uses a uniform generator based on [QCheck.int32]. *)
+(** The [int32] combinator represents the {{!Stdlib.Int32.t}[int32]} type.
+    It uses a uniform generator based on {!QCheck.int32}. *)
 
 val int64 : (Int64.t, 'a, 'b, combinable) ty
-(** The [int64] combinator represents the [int64] type.
-    It uses a uniform generator based on [QCheck.int64]. *)
+(** The [int64] combinator represents the {{!Stdlib.Int64.t}[int64]} type.
+    It uses a uniform generator based on {!QCheck.int64}. *)
 
 val nat64_small : (Int64.t, 'a, 'b, combinable) ty
-(** The [nat64_small] combinator represents the [int64] type.
+(** The [nat64_small] combinator represents the {{!Stdlib.Int64.t}[int64]} type.
     The generated integers are non-negative
-    and are based on [QCheck.small_nat]. *)
+    and are based on {!QCheck.small_nat}. *)
 
 val float : (float, 'a, 'b, combinable) ty
-(** The [float] combinator represents the [float] type.
+(** The [float] combinator represents the {{!Stdlib.Float.t}[float]} type.
     The generated floating point numbers do not include nan and infinities.
-    It is based on [QCheck.float]. *)
+    It is based on {!QCheck.float}. *)
 
 val string : (String.t, 'a, 'b, combinable) ty
-(** The [string] combinator represents the [string] type.
-    The generated strings have a size generated from [QCheck.Gen.nat] and
-    characters resulting from [QCheck.char]. It is based on [QCheck.string]. *)
+(** The [string] combinator represents the {{!Stdlib.String.t}[string]} type.
+    The generated strings have a size generated from {!QCheck.Gen.nat} and
+    characters resulting from {!QCheck.char}. It is based on {!QCheck.string}. *)
 
 val string_small : (String.t, 'a, 'b, combinable) ty
-(** The [small_string] combinator represents the [string] type.
-    The generated strings have a size generated from [QCheck.Gen.small_nat] and
-    characters resulting from [QCheck.char]. It is based on [QCheck.small_string]. *)
+(** The [small_string] combinator represents the {{!Stdlib.String.t}[string]} type.
+    The generated strings have a size generated from {!QCheck.Gen.small_nat} and
+    characters resulting from {!QCheck.char}. It is based on {!QCheck.small_string}. *)
 
 val string_small_printable : (String.t, 'a, 'b, combinable) ty
-(** The [small_string] combinator represents the [string] type.
-    The generated strings have a size generated from [QCheck.Gen.small_nat] and
-    characters resulting from [QCheck.printable_char].
-    It is based on [QCheck.small_printable_string]. *)
+(** The [small_string] combinator represents the {{!Stdlib.String.t}[string]} type.
+    The generated strings have a size generated from {!QCheck.Gen.small_nat} and
+    characters resulting from {!QCheck.printable_char}.
+    It is based on {!QCheck.small_printable_string}. *)
 
 val option :
   ?ratio:float ->
   ('a, 'c, 's, combinable) ty -> ('a option, 'c, 's, combinable) ty
-(** The [option] combinator represents the [option] type.
+(** The [option] combinator represents the {{!Stdlib.Option.t}[option]} type.
     The generated values from [option t] are either [Some v] or [None]
     with [v] being generated by the [t] combinator.
     An optional [ratio] allows to change the default [0.85] [Some]s.
-    It is based on [QCheck.option]. *)
+    It is based on {!QCheck.option}. *)
 
 val opt :
   ?ratio:float ->
@@ -186,38 +186,38 @@ val opt :
 (** The [opt] combinator is an alias for {!option}. *)
 
 val list : ('a, 'c, 's, combinable) ty -> ('a list, 'c, 's, combinable) ty
-(** The [list] combinator represents the [list] type.
-    The generated lists from [list t] have a length resulting from [QCheck.Gen.nat]
+(** The [list] combinator represents the {{!Stdlib.List.t}[list]} type.
+    The generated lists from [list t] have a length resulting from {!QCheck.Gen.nat}
     and have their elements generated by the [t] combinator.
-    It is based on [QCheck.list]. *)
+    It is based on {!QCheck.list}. *)
 
 val array : ('a, 'c, 's, combinable) ty -> ('a array, 'c, 's, combinable) ty
-(** The [array] combinator represents the [array] type.
-    The generated arrays from [array t] have a length resulting from [QCheck.Gen.nat]
+(** The [array] combinator represents the {{!Stdlib.Array.t}[array]} type.
+    The generated arrays from [array t] have a length resulting from {!QCheck.Gen.nat}
     and have their elements generated by the [t] combinator.
-    It is based on [QCheck.array]. *)
+    It is based on {!QCheck.array}. *)
 
 val seq : ('a, 'c, 's, combinable) ty -> ('a Seq.t, 'c, 's, combinable) ty
-(** The [seq] combinator represents the [Seq.t] type.
-    The generated sequences from [seq t] have a length resulting from [QCheck.Gen.nat]
+(** The [seq] combinator represents the {!Stdlib.Seq.t} type.
+    The generated sequences from [seq t] have a length resulting from {!QCheck.Gen.nat}
     and have their elements generated by the [t] combinator. *)
 
 val t : ('a, constructible, 'a, noncombinable) ty
-(** The [t] combinator represents the type [Spec.t] of the system under test. *)
+(** The [t] combinator represents the type {!Spec.t} of the system under test. *)
 
 val state : ('a, constructible, 'a, noncombinable) ty
-(** The [state] combinator represents the type [ApiSpec.t] of the system under test.
+(** The [state] combinator represents the type {!Spec.t} of the system under test.
     It is an alias for the [t] combinator. *)
 
 val or_exn :
   ('a, deconstructible, 'b, combinable) ty ->
   (('a, exn) result, deconstructible, 'c, combinable) ty
 (** The [or_exn] combinator transforms a result type representing [t]
-    into a [(t, exn) result] type. *)
+  into a [(t, exn)] {{!Stdlib.Result.t}[result]} type. *)
 
 val print_result :
   ('a -> string) -> ('b -> string) -> ('a, 'b) result -> string
-(** [print_result pa pb] creates a to-string function for a [(a,b) result] type
+(** [print_result pa pb] creates a to-string function for a [(a,b)] {{!Stdlib.Result.t}[result]} type
     given two to-string functions for [a]s and [b]s, respectively. *)
 
 val print : ('a, 'c, 's, 'comb) ty -> 'a -> string
@@ -274,7 +274,7 @@ val val_ : string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
 
 val val_freq : int -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
 (** [val_freq w str f sig] describes a function signature like
-    [val_ str f sig] but with relative weight [w] rather than 1.
+    {!val_} [str f sig] but with relative weight [w] rather than 1.
     A function of weight 2 will have twice the probability of being
     invoked compared to a function of weight 1. *)
 
@@ -300,7 +300,7 @@ end
 
 module MakeCmd (Spec : Spec) : Internal.CmdSpec [@alert "-internal"]
 (** Functor to map a combinator-based module signature description
-    into a raw [Lin] description.
+    into a raw {!Lin} description.
     This functor is exposed for internal uses only, its API may change
     at any time.
     *)

--- a/lib/lin_effect.mli
+++ b/lib/lin_effect.mli
@@ -1,6 +1,6 @@
 open Lin
 
-(** functor to build an internal module representing effect-based tests *)
+(** functor to build an internal module representing {!Stdlib.Effect}-based tests *)
 module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   module EffSpec : sig
     type cmd
@@ -12,24 +12,24 @@ end
   [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 val fork : (unit -> unit) -> unit
-(** Helper function to fork a process in the underlying [Effect-based] scheduler
+(** Helper function to fork a process in the underlying {!Stdlib.Effect}-based scheduler
 *)
 
 val yield : unit -> unit
-(** Helper function to yield control in the underlying [Effect-based] scheduler
+(** Helper function to yield control in the underlying {!Stdlib.Effect}-based scheduler
 *)
 
 (** functor to build a module for [Effect]-based testing *)
 module Make (Spec : Spec) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
-  (** [lin_test ~count:c ~name:n] builds an [Effect]-based test with the name
+  (** [lin_test ~count:c ~name:n] builds an {!Stdlib.Effect}-based test with the name
       [n] that iterates [c] times. The test fails if one of the generated
       programs is not sequentially consistent. In that case it fails, and prints
       a reduced counter example.
   *)
 
   val neg_lin_test : count:int -> name:string -> QCheck.Test.t
-  (** [neg_lin_test ~count:c ~name:n] builds a negative [Effect]-based test with
+  (** [neg_lin_test ~count:c ~name:n] builds a negative {!Stdlib.Effect}-based test with
       the name [n] that iterates [c] times. The test fails if no counter example
       is found, and succeeds if a counter example is indeed found, and prints it
       afterwards.


### PR DESCRIPTION
Still missing: passes over Lin tutorial and double-checking that links are actually working (using `odig doc` on locally installed packages, or is there a simpler way?).