### PR TITLE
Fix domain_spawntree test failures

### DIFF
--- a/src/domain/domain_spawntree.ml
+++ b/src/domain/domain_spawntree.ml
@@ -74,7 +74,7 @@ let rec dom_interp a = function
 let t ~max_depth ~max_width = Test.make
     ~name:"domain_spawntree - with Atomic"
     ~count:100
-    ~retries:100
+    ~retries:10
     (*~print:show_cmd (gen max_depth max_width)*)
     (make ~print:show_cmd ~shrink:shrink_cmd (gen max_depth max_width))
 
@@ -88,8 +88,9 @@ let t ~max_depth ~max_width = Test.make
             Atomic.get a = interp 0 c
           with
           | Failure s ->
-              if s = "failed to allocate domain"
-              then count_spawns c > max_domains
-              else false))
+            if s = "failed to allocate domain"
+            then true
+            else (Printf.printf "Failure \"%s\"\n%!" s; false)
+       ))
 ;;
 QCheck_base_runner.run_tests_main [t ~max_depth:20 ~max_width:10]


### PR DESCRIPTION
This PR fixes #202 

I added some good old `printf`-debugging to a branch and could then see the reason for the failure:
https://github.com/jmid/multicoretests/actions/runs/3605784474/jobs/6076506977
```
random seed: 530720712
generated error fail pass / total     time test name

[ ]    0    0    0    0 /  100     0.0s domain_spawntree - with Atomic
[ ]    0    0    0    0 /  100     0.0s domain_spawntree - with Atomic (generating)
[ ]    9    0    0    9 /  100    84.7s domain_spawntree - with Atomic
[ ]   30    0    0   30 /  100   169.0s domain_spawntree - with AtomicFailure - failed to allocate domains, count_spawns 936

[ ]   43    0    0   43 /  100   242.7s domain_spawntree - with AtomicFailure - failed to allocate domains, count_spawns 118

[ ]   45    0    0   45 /  100   314.0s domain_spawntree - with Atomic (shrinking:    0)
[ ]   45    0    0   45 /  100   504.7s domain_spawntree - with Atomic (shrinking:    0.0003)
[ ]   45    0    0   45 /  100   673.7s domain_spawntree - with Atomic (shrinking:    0.0004)
[ ]   45    0    0   45 /  100   864.2s domain_spawntree - with Atomic (shrinking:    0.0005)

[...]
```

This is considered a test failure because `118` is less that `max_domains = 128`.
In a context such as `domain_spawntree` which repeatedly spawns and joins several domains
(mapping to underlying `pthreads`) it seems to OK to fail with `Failure failed to allocate domains`
as the `pthreads` can be lagging behind on clearing up after the previous iterations.
The PR therefore adapts the test to accept this behaviour.

While we are at it, `retries` is also reduced to `10` as `100` seems excessive and has contributed to very long CI runs on these failures.